### PR TITLE
CAPX-57: Added logging and user notification for situations when mapped field was removed from bundle/system.

### DIFF
--- a/includes/CAPx/Drupal/Importer/EntityImporterBatch.php
+++ b/includes/CAPx/Drupal/Importer/EntityImporterBatch.php
@@ -125,7 +125,7 @@ class EntityImporterBatch {
     }
 
     $mapper = $importer->getMapper();
-
+    $mapper->checkFields();
     // Allow altering of the results.
     drupal_alter('capx_preprocess_results', $results, $importer);
 
@@ -152,6 +152,5 @@ class EntityImporterBatch {
 
     return TRUE;
   }
-
 
 }

--- a/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
@@ -346,9 +346,8 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
           break;
 
         case "unpublish":
-          $profile->status->value(0);
+          $profile->status->value(array(0));
           $profile->save();
-          drush_log("Unpublished orphaned profile: " . $profile->label(), "status");
           break;
       }
     }

--- a/includes/CAPx/Drupal/Mapper/EntityMapper.php
+++ b/includes/CAPx/Drupal/Mapper/EntityMapper.php
@@ -5,9 +5,11 @@
  */
 
 namespace CAPx\Drupal\Mapper;
+
 use CAPx\Drupal\Processors\FieldProcessors\FieldProcessor;
 use CAPx\Drupal\Processors\PropertyProcessors\PropertyProcessor;
 use CAPx\Drupal\Processors\FieldCollectionProcessor;
+use CAPx\Drupal\Util\CAPxMapper;
 
 class EntityMapper extends MapperAbstract {
 
@@ -54,62 +56,68 @@ class EntityMapper extends MapperAbstract {
 
     // Loop through each field and run a field processor on it.
     foreach ($config['fields'] as $fieldName => $remoteDataPaths) {
-      $info = array();
-
-      drupal_alter('capx_pre_map_field', $entity, $fieldName, $remoteDataPaths);
-
-      // Allow just one path as a string.
-      if (!is_array($remoteDataPaths)) {
-        $remoteDataPaths = array($remoteDataPaths);
-      }
-
-      // Loop through each of the data paths.
-      foreach ($remoteDataPaths as $key => $dataPath) {
-
-        // No setting was provided.
-        if (empty($dataPath)) {
-          continue;
-        }
-
-        // Attempt to get the data based on the path that was provided.
-        // No guarentee that the user wont enter valid jsonpath notation that
-        // does not have a valid result.
-        try {
-          $info[$key] = $this->getRemoteDataByJsonPath($data, $dataPath);
-        } catch(\Exception $e) {
-          // ... silently continue. Please dont shoot me.
-          // @todo: Add debugging logs/help here.
-          continue;
-        }
-      }
-
-      // We got nothing!
-      if (empty($info)) {
-        // @todo: log this
-        continue;
-      }
-
       // Get some information about the field we are going to process.
-      $fieldInfoInstance = field_info_instance($entity->type(), $fieldName, $entity->getBundle());
       $fieldInfoField = field_info_field($fieldName);
+      if ($fieldInfoField) {
+        $fieldInfoInstance = field_info_instance($entity->type(), $fieldName, $entity->getBundle());
+        if ($fieldInfoInstance) {
+          $info = array();
 
-      // Widgets can change the way the data needs to be parsed. Provide that
-      // to the FieldProcessor.
-      $widget = $fieldInfoInstance['widget']['type'];
-      $field = $fieldInfoField['type'];
+          drupal_alter('capx_pre_map_field', $entity, $fieldName, $remoteDataPaths);
 
-      // Create a new field processor and let it do its magic.
-      $fieldProcessor = new FieldProcessor($entity, $fieldName);
-      $fieldProcessor->field($field)->widget($widget)->put($info);
+          // Allow just one path as a string.
+          if (!is_array($remoteDataPaths)) {
+            $remoteDataPaths = array($remoteDataPaths);
+          }
 
-      // Allow altering of an entity after this process.
-      drupal_alter('capx_post_map_field', $entity, $fieldName);
+          // Loop through each of the data paths.
+          foreach ($remoteDataPaths as $key => $dataPath) {
 
+            // No setting was provided.
+            if (empty($dataPath)) {
+              continue;
+            }
+
+            // Attempt to get the data based on the path that was provided.
+            // No guarentee that the user wont enter valid jsonpath notation that
+            // does not have a valid result.
+            try {
+              $info[$key] = $this->getRemoteDataByJsonPath($data, $dataPath);
+            }
+            catch (\Exception $e) {
+              $message = 'There was an exception when trying to get data by @path. Exception message is: @message.';
+              $message_vars = array(
+                '@path' => $dataPath,
+                '@message' => $e->getMessage(),
+              );
+              watchdog('stanford_capx_jsonpath', $message, $message_vars);
+              continue;
+            }
+          }
+
+          // We got nothing!
+          if (empty($info)) {
+            // @todo: log this
+            continue;
+          }
+
+          // Widgets can change the way the data needs to be parsed. Provide that
+          // to the FieldProcessor.
+          $widget = $fieldInfoInstance['widget']['type'];
+          $field = $fieldInfoField['type'];
+
+          // Create a new field processor and let it do its magic.
+          $fieldProcessor = new FieldProcessor($entity, $fieldName);
+          $fieldProcessor->field($field)->widget($widget)->put($info);
+
+          // Allow altering of an entity after this process.
+          drupal_alter('capx_post_map_field', $entity, $fieldName);
+        }
+      }
     }
 
     // Set the entity again for changes.
     $this->setEntity($entity);
-
   }
 
   /**
@@ -196,5 +204,71 @@ class EntityMapper extends MapperAbstract {
     $this->setEntity($entity);
   }
 
+  /**
+   * Checks that fields used in this mapper still in place.
+   *
+   * If it happens that field used in mapper will be removed from bundle
+   * or from the system entirely this will put a watchdog message and put a
+   * persistent message for admin users on admin pages.
+   */
+  public function checkFields() {
+    $config = $this->getConfig();
+    $entity_type = $config['entity_type'];
+    $bundle = $config['bundle_type'];
+    $fields = $config['fields'];
 
+    foreach (array_keys($fields) as $fieldName) {
+      $fieldInfoField = field_info_field($fieldName);
+      if ($fieldInfoField) {
+        $fieldInfoInstance = field_info_instance($entity_type, $fieldName, $bundle);
+        if (!$fieldInfoInstance) {
+          // Field was removed from this bundle.
+          $messages = variable_get('stanford_capx_field_issues', array());
+          $mapper = $this->getMapper();
+          $message_key = $mapper->getMachineName() . ':' . $entity_type . ':' . $bundle . ':' . $fieldName;
+
+          if (empty($messages[$message_key])) {
+            $message_vars = array(
+              '%field' => $fieldName,
+              '%entity_type' => $entity_type,
+              '%bundle' => $bundle,
+              '!mapper' => l(check_plain($mapper->label()), 'admin/config/capx/mapper/edit/' . $mapper->getMachineName()),
+            );
+            $message = t('Field %field was removed from the %entity_type bundle %bundle, but is still used in !mapper. You should check configuration of the specified mapper!');
+            watchdog('stanford_capx_field_issues', $message, $message_vars, WATCHDOG_ERROR);
+            $messages[$message_key] = array(
+              'text' => $message,
+              'message_vars' => $message_vars,
+            );
+            variable_set('stanford_capx_field_issues', $messages);
+          }
+        }
+      }
+      else {
+        // Field was removed from system.
+        $messages = variable_get('stanford_capx_field_issues', array());
+        $message_key = $fieldName;
+
+        if (empty($messages[$message_key])) {
+          $mappers = CAPxMapper::loadAllMappers();
+          // Filtering mappers that uses this field.
+          $mapper_links = array();
+          foreach ($mappers as $mapper) {
+            if (array_key_exists($fieldName, $mapper->fields)) {
+              $mapper_links[$mapper->getMachineName()] = l(check_plain($mapper->label()), 'admin/config/capx/mapper/edit/' . $mapper->getMachineName());
+            }
+          }
+          $message_vars = array('%field' => $fieldName, '!mappers' => implode(', ', $mapper_links));
+          $message = t('Field %field was removed from the system, but is still used in !mappers. You should check configuration of the specified mappers!');
+          watchdog('stanford_capx_field_issues', $message, $message_vars, WATCHDOG_ERROR);
+          $messages[$message_key] = array(
+            'text' => $message,
+            'message_vars' => $message_vars,
+            'mappers' => $mapper_links,
+          );
+          variable_set('stanford_capx_field_issues', $messages);
+        }
+      }
+    }
+  }
 }

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -841,6 +841,41 @@ function stanford_capx_mapper_form_submit($form, $form_state) {
   // Do the save.
   capx_mapper_save($mapper);
 
+  // Lets check the error messages that may be related to this mapper.
+  $messages = variable_get('stanford_capx_field_issues', array());
+  foreach ($messages as $key => &$message) {
+    $message_meta = explode(':', $key);
+    // When the field is missing from some bundle in
+    // \CAPx\Drupal\Mapper\EntityMapper::mapFields we creating key from 4
+    // components:
+    // - mapper machine name
+    // - entity type
+    // - entity bundle
+    // - entity field name
+    // In this exact order.
+    if (count($message_meta) === 4) {
+      if (
+        $message_meta[0] == $values['machine-name']
+        && $message_meta[1] == $entity
+        && $message_meta[2] == $bundle
+      ) {
+        unset($messages[$key]);
+      }
+    }
+    elseif (!empty($message['mappers']) && array_key_exists($values['machine-name'], $message['mappers'])) {
+      unset($message['mappers'][$values['machine-name']]);
+
+      if (empty($message['mappers'])) {
+        // This was the last mapper that were using deleted field.
+        unset($messages[$key]);
+      }
+      else {
+        $message['message_vars']['!mappers'] = implode(', ', $message['mappers']);
+      }
+    }
+  }
+  variable_set('stanford_capx_field_issues', $messages);
+
   // Are we sure we want this?
   drupal_goto('admin/config/capx/mapper');
 }

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -524,3 +524,29 @@ function stanford_capx_files_dir_exists() {
 
   return FALSE;
 }
+
+/**
+ * Implements hook_init().
+ *
+ * Shows error messages to admin user on admin pages.
+ */
+function stanford_capx_init() {
+  $path = current_path();
+  if (user_access('administer capx') && path_is_admin($path) && $path != 'batch') {
+
+    // We don't want to set message on "stanford_capx_mapper_form" form
+    // submission because message get set before it's processed in the submit
+    // handler and this can confuse a user if this mapper was the last one that
+    // was affected by issue specified in the message.
+    if (empty($_POST['form_id']) || $_POST['form_id'] != 'stanford_capx_mapper_form') {
+      $messages = variable_get('stanford_capx_field_issues', array());
+      foreach ($messages as $key => $message) {
+        $formatted_message = format_string(
+          $message['text'],
+          isset($message['message_vars']) ? $message['message_vars'] : NULL
+        );
+        drupal_set_message($formatted_message, 'error', FALSE);
+      }
+    }
+  }
+}


### PR DESCRIPTION
CAPX-57: Added logging and user notification for situations when mapped field was removed from bundle/system.

How To test:
Added a field to multiple entity bundles
Create multiple mappers using this entity
Remove created field from ONE of bundles
Create an importer with one of this mappers and start import
You should see a message telling you that field is missing from a bundle
Editing a mapper from the message should remove it(note that after resaving mentioned mapper you will see the message one more time)
Remove created field from all bundles and run cron to ensure it was completely removed from the system
Create new importer using another mapper created earlier and start import
Now will see a message stating that field was removed with a list of mappers affected
Message will disappear when ALL mappers affected will be resaved
