### PR TITLE
CAPX-41 | Importer in use block + Orphan processing do nothing action

### DIFF
--- a/css/stanford_capx.admin.css
+++ b/css/stanford_capx.admin.css
@@ -5,3 +5,9 @@
   padding: 0 1% 1% 1%;
   border: solid 1px #CCC;
 }
+
+#block-stanford-capx-importer-in-use {
+  background: #FFC;
+  padding: 20px;
+  border: solid 1px #333;
+}

--- a/includes/CAPx/Drupal/Importer/EntityImporter.php
+++ b/includes/CAPx/Drupal/Importer/EntityImporter.php
@@ -298,6 +298,13 @@ class EntityImporter implements ImporterInterface {
    *
    */
   public function createOrphansQueue() {
+
+    // If the action is set to do nothing to orphaned profiles, do nothing.
+    $action = variable_get("stanford_capx_orphan_action", "unpublish");
+    if ($action == "nothing") {
+      return;
+    }
+
     $limit = variable_get('stanford_capx_batch_limit', 100);
 
     // Get a list of all the profiles that are associated with this importer.

--- a/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
@@ -85,6 +85,12 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
    */
   public function execute() {
 
+    // If the action is set to do nothing to orphaned profiles, do nothing.
+    $action = variable_get("stanford_capx_orphan_action", "unpublish");
+    if ($action == "nothing") {
+      return;
+    }
+
     $importer =  $this->getImporter();
     $options = $this->getImporterOptions();
     $profiles = $this->getProfiles();
@@ -341,15 +347,22 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
 
       switch ($action) {
         case "delete":
-          drush_log("Deleted orphaned profile: " . $profile->label(), "status");
+          if (function_exists("drush_log")) {
+            drush_log("Deleted orphaned profile: " . $profile->label(), "status");
+          }
           $profile->delete();
           break;
 
         case "unpublish":
           $profile->status->value(0);
           $profile->save();
-          drush_log("Unpublished orphaned profile: " . $profile->label(), "status");
+          if (function_exists("drush_log")) {
+            drush_log("Unpublished orphaned profile: " . $profile->label(), "status");
+          }
           break;
+
+        default:
+          // Do nothing.
       }
     }
 

--- a/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
@@ -347,18 +347,12 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
 
       switch ($action) {
         case "delete":
-          if (function_exists("drush_log")) {
-            drush_log("Deleted orphaned profile: " . $profile->label(), "status");
-          }
           $profile->delete();
           break;
 
         case "unpublish":
           $profile->status->value(0);
           $profile->save();
-          if (function_exists("drush_log")) {
-            drush_log("Unpublished orphaned profile: " . $profile->label(), "status");
-          }
           break;
 
         default:

--- a/stanford_capx.blocks.inc
+++ b/stanford_capx.blocks.inc
@@ -172,7 +172,9 @@ function stanford_capx_data_browser_launch_block() {
 
 /**
  * Creates and displays the importer in use block.
- * @return [type] [description]
+ *
+ * @return string
+ *   HTML representation of the page.
  */
 function stanford_capx_importer_in_use_block() {
   $output = "";

--- a/stanford_capx.blocks.inc
+++ b/stanford_capx.blocks.inc
@@ -8,6 +8,7 @@
 
 use CAPx\Drupal\Util\CAPx;
 use CAPx\Drupal\Util\CAPxConnection;
+use CAPx\Drupal\Util\CAPxImporter;
 
 /**
  * Implements hook_block_info().
@@ -28,7 +29,15 @@ function stanford_capx_block_info() {
     'region' => 'help',
     'visibility' => BLOCK_VISIBILITY_LISTED,
     'pages' => 'admin/config/capx/mapper/*',
+  );
 
+  $blocks['importer_in_use'] = array(
+    'info' => t('Importer In Use'),
+    'cache' => DRUPAL_NO_CACHE,
+    'properties' => array('administrative' => 1),
+    'region' => 'help',
+    'visibility' => BLOCK_VISIBILITY_LISTED,
+    'pages' => 'admin/config/capx/importer/edit/*',
   );
 
   return $blocks;
@@ -50,6 +59,19 @@ function stanford_capx_block_view($delta = '') {
     case "data_browser_launch":
       $block['subject'] = t('Data Browser');
       $block['content'] = stanford_capx_data_browser_launch_block();
+      break;
+
+    case "importer_in_use":
+      $block['subject'] = t('Importer In Use');
+      $block['title'] = t('Importer In Use');
+      $block['content'] = array(
+        '#markup' => stanford_capx_importer_in_use_block(),
+        '#attached' => array(
+          'css' => array(
+            drupal_get_path('module', 'stanford_capx') . '/css/stanford_capx.admin.css',
+          ),
+        ),
+      );
       break;
 
   }
@@ -144,6 +166,39 @@ function stanford_capx_data_browser_launch_block() {
   $rows[] = array('Field of study', '$.education.*.fieldOfStudy');
   $rows[] = array('Type', '$.titles.*.type');
   $output .= theme('table', array('rows' => $rows));
+
+  return $output;
+}
+
+/**
+ * Creates and displays the importer in use block.
+ * @return [type] [description]
+ */
+function stanford_capx_importer_in_use_block() {
+  $output = "";
+
+  // Get machine name from url.
+  $machine_name = arg(5);
+
+  // If no machine name this must be a new importer. Just end.
+  if (empty($machine_name)) {
+    return;
+  }
+
+  // Do not need to check to see if this works or not as the page wont load if
+  // the machine name is invalid.
+  $importer = CAPxImporter::loadEntityImporter($machine_name);
+
+  // The metadata.
+  $meta = $importer->getMeta();
+
+  $output .= "<p>";
+  $output .= t("This importer is currently used to import !num profiles. Add or delete profiles by changing the settings below.", array("!num" => "<strong>" . $meta['count'] . "</strong>"));
+  $output .= "</p><p>";
+  $output .= t("Configure your !link to determine what will happen when profiles are deleted from your Importer or the CAP API.", array("!link" => l(t("CAPx Settings"), "admin/config/capx/settings")));
+  $output .= "</p><p>";
+  $output .= l(t("View all imported profiles"), "admin/config/capx/profiles", array("query" => array("importer" => $machine_name), "attributes" => array("class" => array("button"))));
+  $output .= "</p>";
 
   return $output;
 }

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -983,13 +983,13 @@ function stanford_capx_importer_form($form, &$form_state, $importer = NULL) {
   $form['cron'] = array(
     '#title' => t('Sync options'),
     '#type' => 'fieldset',
-    '#collapsed' => FALSE,
-    '#collapsible' => FALSE,
+    '#collapsed' => !empty($importer),
+    '#collapsible' => TRUE,
   );
 
   $form['cron']['cron_option'] = array(
     '#title' => t('Sync'),
-    '#description' => t('Select an interval on how often this importer should syncronize with the CAP server. This setting is dependant on !cron.', array('!cron' => l('cron configuration', 'admin/config/system/cron'))),
+    '#description' => t('Select an interval on how often this importer should syncronize with the CAP server. This setting is dependant on !cron.', array('!cron' => l(t('cron configuration'), 'admin/config/system/cron'))),
     '#type' => 'select',
     '#options' => CAPxImporter::getCronOptions(),
     '#default_value' => isset($importer->cron_option) ? $importer->cron_option : 'daily',
@@ -1482,7 +1482,8 @@ function stanford_capx_forms_config_settings($form, &$form_state) {
     '#description' => t('What should happen to a profile that is marked as orphaned?'),
     '#type' => "select",
     '#options' => array(
-      'unpublish' => t('Unpublish'),
+      'nothing' => t("Nothing"),
+      'unpublish' => t('Unpublish - Nodes only'),
       'delete' => t('Delete'),
     ),
     '#default_value' => variable_get('stanford_capx_orphan_action', 'unpublish'),


### PR DESCRIPTION
# Ready for review

To test:
1. Create a new importer complete with mapper
2. Import some profiles
3. Edit importer to see the block at the top of the page
4. Ensure that the number of profiles imported is correct
5. Click the configuration link and the view profiles button. View profiles should take you to a filtered view by machine name.

The orphan functionality that snuck into this PR is pretty simple. If the user selects the option to do nothing with orphaned profiles then don't bother checking for them at all as that is extra processing overhead. 
