### PR TITLE
CAPX-28: Mapper in use block

### DIFF
--- a/css/stanford_capx.admin.css
+++ b/css/stanford_capx.admin.css
@@ -1,13 +1,14 @@
 #block-stanford-capx-data-browser-launch {
   float: right;
   width: 28%;
-  margin: 0 0 20px 12px;
+  margin: 12px 0 20px 12px;
   padding: 0 1% 1% 1%;
   border: solid 1px #CCC;
 }
 
+#block-stanford-capx-mapper-in-use,
 #block-stanford-capx-importer-in-use {
   background: #FFC;
-  padding: 20px;
+  padding: 10px 20px;
   border: solid 1px #333;
 }

--- a/stanford_capx.blocks.inc
+++ b/stanford_capx.blocks.inc
@@ -9,6 +9,7 @@
 use CAPx\Drupal\Util\CAPx;
 use CAPx\Drupal\Util\CAPxConnection;
 use CAPx\Drupal\Util\CAPxImporter;
+use CAPx\Drupal\Util\CAPxMapper;
 
 /**
  * Implements hook_block_info().
@@ -33,11 +34,19 @@ function stanford_capx_block_info() {
 
   $blocks['importer_in_use'] = array(
     'info' => t('Importer In Use'),
-    'cache' => DRUPAL_NO_CACHE,
+    'cache' => DRUPAL_CACHE_PER_PAGE,
     'properties' => array('administrative' => 1),
     'region' => 'help',
     'visibility' => BLOCK_VISIBILITY_LISTED,
     'pages' => 'admin/config/capx/importer/edit/*',
+  );
+
+  $blocks['mapper_in_use'] = array(
+    'info' => t('Mapper In Use'),
+    'cache' => DRUPAL_CACHE_PER_PAGE,
+    'properties' => array('administrative' => 1),
+    'visibility' => BLOCK_VISIBILITY_LISTED,
+    'pages' => 'admin/config/capx/mapper/edit/*',
   );
 
   return $blocks;
@@ -64,14 +73,13 @@ function stanford_capx_block_view($delta = '') {
     case "importer_in_use":
       $block['subject'] = t('Importer In Use');
       $block['title'] = t('Importer In Use');
-      $block['content'] = array(
-        '#markup' => stanford_capx_importer_in_use_block(),
-        '#attached' => array(
-          'css' => array(
-            drupal_get_path('module', 'stanford_capx') . '/css/stanford_capx.admin.css',
-          ),
-        ),
-      );
+      $block['content'] = stanford_capx_importer_in_use_block();
+      break;
+
+    case "mapper_in_use":
+      $block['subject'] = t('Mapper In Use');
+      $block['title'] = t('Mapper In Use');
+      $block['content'] = stanford_capx_mapper_in_use_block();
       break;
 
   }
@@ -184,7 +192,7 @@ function stanford_capx_importer_in_use_block() {
 
   // If no machine name this must be a new importer. Just end.
   if (empty($machine_name)) {
-    return;
+    return FALSE;
   }
 
   // Do not need to check to see if this works or not as the page wont load if
@@ -194,6 +202,10 @@ function stanford_capx_importer_in_use_block() {
   // The metadata.
   $meta = $importer->getMeta();
 
+  if ((int) $meta['count'] <= 0) {
+    return FALSE;
+  }
+
   $output .= "<p>";
   $output .= t("This importer is currently used to import !num profiles. Add or delete profiles by changing the settings below.", array("!num" => "<strong>" . $meta['count'] . "</strong>"));
   $output .= "</p><p>";
@@ -202,5 +214,68 @@ function stanford_capx_importer_in_use_block() {
   $output .= l(t("View all imported profiles"), "admin/config/capx/profiles", array("query" => array("importer" => $machine_name), "attributes" => array("class" => array("button"))));
   $output .= "</p>";
 
-  return $output;
+  return array(
+    '#markup' => $output,
+    '#attached' => array(
+      'css' => array(
+        drupal_get_path('module', 'stanford_capx') . '/css/stanford_capx.admin.css',
+      ),
+    ),
+  );
+
+}
+
+
+/**
+ * Creates the mapper in use block hook_view().
+ *
+ * Creates a render array of information to use on a mapper page.
+ *
+ * @return array
+ *   A render array of block information.
+ */
+function stanford_capx_mapper_in_use_block() {
+  $output = "";
+
+  // Get machine name from url.
+  $machine_name = arg(5);
+
+  // If no machine name this must be a new importer. Just end.
+  if (empty($machine_name)) {
+    return FALSE;
+  }
+
+  // Do not need to check to see if this works or not as the page wont load if
+  // the machine name is invalid.
+  $mapper = CAPxMapper::loadMapper($machine_name);
+  $importers = CAPxImporter::loadImportersByMapper($mapper);
+
+  if (empty($importers)) {
+    return FALSE;
+  }
+
+  $output .= "<p>";
+  $output .= t("WARNING: Any changes you make to this mapper will update existing content on your next CAP sync.");
+  $output .= "</p><p>";
+  $output .= t("This Mapper is currently used by: ");
+
+  $porters = array();
+  foreach ($importers as $k => $importer) {
+    $porters[] = l(t("!title", array("!title" => $importer->title)), "admin/config/capx/importer/edit/" . $importer->getMachineName());
+  }
+
+  $output .= implode(", ", $porters);
+  $output .= "</p><p>";
+  $output .= l(t("View all imported profiles"), "admin/config/capx/profiles", array("attributes" => array("class" => "button")));
+  $output .= "</p>";
+
+  return array(
+    '#markup' => $output,
+    '#attached' => array(
+      'css' => array(
+        drupal_get_path('module', 'stanford_capx') . '/css/stanford_capx.admin.css',
+      ),
+    ),
+  );
+
 }

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -1056,7 +1056,7 @@ function stanford_capx_importer_form($form, &$form_state, $importer = NULL) {
   $has_orgs = \CAPx\Drupal\Organizations\Orgs::checkOrgs();
   if (!$has_orgs) {
     $link = l('Sync with the API now.', 'admin/config/capx/organizations/sync', array('query' => array('destination' => current_path())));
-    drupal_set_message(t('The organization codes are not available. @link', array("@link" => $link)), 'warning');
+    drupal_set_message(t('The organization codes are not available. !link', array("!link" => $link)), 'warning');
   }
 
   // Configuration group

--- a/stanford_capx.pages.inc
+++ b/stanford_capx.pages.inc
@@ -155,11 +155,15 @@ function stanford_capx_admin_config_mapper_edit($mapper_machine_name) {
   $output['#attached']['css'][] = drupal_get_path('module', 'stanford_capx') . "/css/stanford_capx.admin.css";
 
   // Data browser block.
+  $block = block_load('stanford_capx', 'mapper_in_use');
+  $output['content']['mapper_in_use'] = _block_get_renderable_array(_block_render_blocks(array($block)));
+
+  // Data browser block.
   $block = block_load('stanford_capx', 'data_browser_launch');
-  $output += _block_get_renderable_array(_block_render_blocks(array($block)));
+  $output['content']['data_browser_launch'] = _block_get_renderable_array(_block_render_blocks(array($block)));
 
   // Render form.
-  $output += drupal_get_form('stanford_capx_mapper_form', $mapper);
+  $output['content']['mapper_form'] = drupal_get_form('stanford_capx_mapper_form', $mapper);
 
   return $output;
 }
@@ -194,16 +198,18 @@ function stanford_capx_admin_config_import_new() {
  *   HTML representation of this page.
  */
 function stanford_capx_admin_config_import_edit($importer_machine_name) {
-  $output = "";
+  $output = array();
   $importer = CAPxImporter::loadImporter($importer_machine_name);
 
   if (!$importer) {
     throw new Exception(t("Could not load an importer with provided machine name. Please check url."));
   }
 
+  // The in use block.
+  $output['content']["in_use_block"] = _block_get_renderable_array(_block_render_blocks(array(block_load('stanford_capx', 'importer_in_use'))));
+
   // Render form.
-  $form = drupal_get_form('stanford_capx_importer_form', $importer);
-  $output .= drupal_render($form);
+  $output['content']["importer_form"] = drupal_get_form('stanford_capx_importer_form', $importer);
 
   return $output;
 }


### PR DESCRIPTION
# Ready for review

dependant on: #24 
#### Adds a mapper in use block to the top of mapper pages.

To test:
- Create new mapper
- Edit that new mapper and see no block at top of page
- Create or use existing importer and select the newly created mapper. Do this two or three times.
- Edit that new mapper again and see block at the top of page

A small change to the importer in use block snuck in here as well to prevent it from showing content if nothing to show.
