### PR TITLE
CAPX-4: Added callback to sync all configured importers.

### DIFF
--- a/includes/CAPx/Drupal/Util/CAPxImporter.php
+++ b/includes/CAPx/Drupal/Util/CAPxImporter.php
@@ -83,6 +83,29 @@ class CAPxImporter {
   }
 
   /**
+   * Returns all EntityImporter.
+   *
+   * @return array
+   *   An array of fully instantiated EntityImporters.
+   */
+  public static function getAllEntityImporters() {
+    $entity_importers = array();
+
+    $importers = self::loadAllImporters();
+
+    foreach ($importers as $importer) {
+      $mapper = CAPxMapper::loadEntityMapper($importer->mapper);
+      $client = CAPxConnection::getAuthenticatedHTTPClient();
+      $entity_importer = new EntityImporter($importer, $mapper, $client);
+
+      // @todo: Add validation once CAPX-58 get in.
+      $entity_importers[$entity_importer->getMachineName()] = $entity_importer;
+    }
+
+    return $entity_importers;
+  }
+
+  /**
    * Loads EntityImporter's filtered by mapper.
    *
    * @param CFEntity $mapper

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -236,6 +236,13 @@ function stanford_capx_menu() {
     'type' => MENU_NORMAL_ITEM,
   );
 
+  $items['admin/config/capx/importer/sync-all'] = array(
+    'title' => 'Sync All Importers',
+    'page callback' => 'stanford_capx_sync_all_importers',
+    'access arguments' => array('administer capx'),
+    'type' => MENU_CALLBACK,
+  );
+
   // Profile pages
   // ---------------------------------------------------------------------------
 

--- a/stanford_capx.pages.inc
+++ b/stanford_capx.pages.inc
@@ -282,3 +282,17 @@ function stanford_capx_debug() {
   $output .= "Hey!";
   return $output;
 }
+
+/**
+ * Runs a batch on all importers.
+ */
+function stanford_capx_sync_all_importers() {
+
+  $importers = CAPxImporter::getAllEntityImporters();
+
+  foreach ($importers as $importer) {
+    $importer->createBatch();
+  }
+
+  batch_process(drupal_get_destination());
+}


### PR DESCRIPTION
How to test:
- Create multiple importers, but don't run the real import.
- Use path "admin/config/capx/importer/sync-all?destination=admin/config/capx/importer" to initiate synchronization of all importers.
