### PR TITLE
CAPX-92 Prevented deletion of imported entity

### DIFF
--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -77,14 +77,18 @@ function stanford_capx_permission() {
  * Implements hook_node_access().
  */
 function stanford_capx_node_access($node, $op, $account) {
-  // Returning nothing from this function would have the same effect.
-  return NODE_ACCESS_IGNORE;
+  $access = NODE_ACCESS_IGNORE;
+
+  // Disable deletion of nodes synced from CAP.
+  if ($op == 'delete' && isset($node->capx) && !empty($node->capx['sync'])) {
+    $access = NODE_ACCESS_DENY;
+  }
+
+  return $access;
 }
 
 /**
- * Implements hook_views_api.
- * @return array
- *   returns views api info
+ * Implements hook_views_api().
  */
 function stanford_capx_views_api() {
   return array(

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -579,3 +579,14 @@ function stanford_capx_form_user_profile_form_alter(&$form, &$form_state) {
     $form['actions']['cancel']['#access'] = FALSE;
   }
 }
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function stanford_capx_form_taxonomy_form_term_alter(&$form, &$form_state) {
+  global $user;
+  // Disable deletion of taxonomy terms synced from CAP.
+  if ($user->uid != 1 && isset($form_state['term']->capx) && !empty($form_state['term']->capx['sync'])) {
+    $form['actions']['delete']['#access'] = FALSE;
+  }
+}

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -568,3 +568,14 @@ function stanford_capx_init() {
     }
   }
 }
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function stanford_capx_form_user_profile_form_alter(&$form, &$form_state) {
+  global $user;
+  // Disable deletion of users synced from CAP.
+  if ($user->uid != 1 && isset($form_state['user']->capx) && !empty($form_state['user']->capx['sync'])) {
+    $form['actions']['cancel']['#access'] = FALSE;
+  }
+}


### PR DESCRIPTION
Disabled deletion of imported nodes, users and terms with the UI.

Nodes disabled via access check alteration, too bad this cannpt be done for users and terms.

How to test:
- Import some profiles mapping them to nodes
- Open for editing any imported profile as user other then user with ID 1 - you will not see "Delete" button
