### PR TITLE
CAPX-93: Added enable/disable synchronization functionality.

### DIFF
--- a/includes/CAPx/Drupal/Processors/EntityProcessor.php
+++ b/includes/CAPx/Drupal/Processors/EntityProcessor.php
@@ -27,8 +27,7 @@ class EntityProcessor extends ProcessorAbstract {
     $entityType = $mapper->getEntityType();
     $bundleType = $mapper->getBundleType();
 
-    // $entity = CAPx::getEntityByProfileId($entityType, $bundleType, $data['profileId']);
-    $entity = null;
+    $entity = NULL;
     $entities = CAPx::getProfiles($entityType, array('profile_id' => $data['profileId'], 'importer' => $importerMachineName));
     if (is_array($entities)) {
       $entity = array_pop($entities);
@@ -36,6 +35,12 @@ class EntityProcessor extends ProcessorAbstract {
 
     // If we have an entity we need to update it.
     if (!empty($entity)) {
+
+      // Profile synchronization has been disabled.
+      if (empty($entity->capx['sync'])) {
+        return NULL;
+      }
+
       $this->setEntity($entity);
 
       // Check to see if the etag has changed. We can avoid processing a profile

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -1527,6 +1527,21 @@ function stanford_capx_entity_form_add_vt(&$form, &$form_state, $form_id, $entit
 
   $form['capx_vertical_tab']['tmpinfo']['#markup'] = $table;
 
+  if (user_access('administer capx')) {
+    $sync = empty($entity->capx['sync']) ? TRUE : FALSE;
+    $button_text = $sync ? t('Enable updates from CAP for this profile') : t('Disable updates from CAP for this profile');
+    $path = 'admin/config/capx/profile-sync/' . $entity->capx['id'] . '/';
+    $path .= $sync ? 'enable' : 'disable';
+    $options = array(
+      'attributes' => array(
+        'class' => array('button'),
+      ),
+      'query' => array(
+        'destination' => $_GET['q'],
+      ),
+    );
+    $form['capx_vertical_tab']['disable_sync']['#markup'] = l($button_text, $path, $options);
+  }
 }
 
 /**

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -258,6 +258,14 @@ function stanford_capx_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items['admin/config/capx/profile-sync/%/%'] = array(
+    'title' => 'Profile synchronization settings change callback',
+    'page callback' => 'stanford_capx_profile_sync_status',
+    'page arguments' => array(4, 5),
+    'access arguments' => array('administer capx'),
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
 }
 
@@ -563,4 +571,36 @@ function stanford_capx_init() {
       }
     }
   }
+}
+
+/**
+ * Page callback for changing profile sync status.
+ *
+ * @param int $id
+ *   Internal profile ID.
+ *
+ * @param string $sync
+ *   Synchronization operation. One from 'enable', 'disable'.
+ */
+function stanford_capx_profile_sync_status($id, $sync) {
+  $sync_value = NULL;
+
+  switch ($sync) {
+    case 'enable':
+      $sync_value = 1;
+      break;
+
+    case 'disable':
+      $sync_value = 0;
+      break;
+  }
+
+  if (isset($sync_value)) {
+    db_update('capx_profiles')
+      ->condition('id', $id)
+      ->fields(array('sync' => $sync_value))
+      ->execute();
+  }
+
+  drupal_goto();
 }


### PR DESCRIPTION
CAPX-93: Added enable/disable synchronization functionality.

How to test:
- Import profile you have access to in CAP
- Disable synchronization on profile edit page
- Update profile in CAP
- Wrote down profile last update timestamp
- Click "Update profiles now" link on importers page
- Compare update timestamp of the profile, it should be the same
