### PR TITLE
CAPX-99: Allowed to save empty "summary" column value in mapper.

### DIFF
--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -762,7 +762,7 @@ function stanford_capx_mapper_form_validate_required_fields(&$form, &$form_state
 
       // Loop through the columns and check for values.
       foreach ($columns as $column_name => $value) {
-        if (empty($value)) {
+        if (empty($value) && $column_name != 'summary') {
           $element = "field-mapping][" . $entity . "-" . $bundle . "-" . "fields][" . $field_name . "][" . $column_name;
           form_set_error($element, t("@name field is required", array("@name" => $field_name)));
           break;


### PR DESCRIPTION
CAPX-99: Allowed to save empty "summary" column value in mapper.

How to test:
- Set body field to be required on page content type
- Create a mapper with page content type
- Fill in only value column for body field
- Save mapper 
