### PR TITLE
CAPX-107: Moved orphan handling to importer.

### DIFF
--- a/includes/CAPx/Drupal/Importer/EntityImporter.php
+++ b/includes/CAPx/Drupal/Importer/EntityImporter.php
@@ -321,13 +321,12 @@ class EntityImporter implements ImporterInterface {
    * Search through the values we have and find orphans in the api.
    *
    * Create queue api queues that run on cron to check for orphans.
-   *
    */
   public function createOrphansQueue() {
 
     // If the action is set to do nothing to orphaned profiles, do nothing.
-    $action = variable_get("stanford_capx_orphan_action", "unpublish");
-    if ($action == "nothing") {
+    $options = $this->getOptions();
+    if ($options['orphan_action'] == 'nothing') {
       return;
     }
 

--- a/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
@@ -81,13 +81,12 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
 
   /**
    * Process handling for queue items.
-   *
    */
   public function execute() {
 
     // If the action is set to do nothing to orphaned profiles, do nothing.
-    $action = variable_get("stanford_capx_orphan_action", "unpublish");
-    if ($action == "nothing") {
+    $options = $this->getImporterOptions();
+    if ($options['orphan_action'] == 'nothing') {
       return;
     }
 
@@ -336,7 +335,8 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
     $importer = $this->getImporter();
     $entityType = $importer->getEntityType();
     $bundleType = $importer->getBundleType();
-    $action = variable_get("stanford_capx_orphan_action", "unpublish");
+    $options = $this->getImporterOptions();
+    $action = $options['orphan_action'];
 
     foreach ($profileIds as $id) {
       $profile = CAPx::getEntityByProfileId($entityType, $bundleType, $id);
@@ -348,20 +348,17 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
       $profile = entity_metadata_wrapper($entityType, $profile);
 
       switch ($action) {
-        case "delete":
+        case 'delete':
           $profile->delete();
           break;
 
-        case "unpublish":
-
-          if ($entityType == "node") {
-            $profile->status->set(0);
-            $profile->save();
-          }
+        case 'block':
+        case 'unpublish':
+          $profile->status->set(0);
+          $profile->save();
 
           // Log that this profile was orphaned.
           $this->logOrphan($profile);
-
           break;
 
         default:

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -1096,7 +1096,7 @@ function stanford_capx_importer_form($form, &$form_state, $importer = NULL) {
     '#disabled' => isset($importer->machine_name),
   );
 
-  // Create options...
+  // Mapper options.
   $mapping_options = array();
   $mappers = CAPxMapper::loadAllMappers();
 
@@ -1104,7 +1104,7 @@ function stanford_capx_importer_form($form, &$form_state, $importer = NULL) {
     drupal_set_message(t("No mappers found. Please !maplink before proceeding with this importer.", array("!maplink" => l(t("create a mapper"), "admin/config/capx/mapper/new"))), "error");
   }
 
-  foreach ($mappers as $cfid => $mapper) {
+  foreach ($mappers as $mapper) {
     $mapping_options[$mapper->machine_name] = $mapper->title;
   }
 
@@ -1115,6 +1115,50 @@ function stanford_capx_importer_form($form, &$form_state, $importer = NULL) {
     '#options' => $mapping_options,
     '#default_value' => isset($importer->mapper) ? $importer->mapper : '',
     '#required' => TRUE,
+    '#empty_option' => t('--Please select--'),
+    '#ajax' => array(
+      'wrapper' => 'orphan-action-wrapper',
+      'callback' => '_stanford_capx_importer_form_mapper_ajax_callback'
+    ),
+  );
+
+  // Orphan action section.
+  $action_options = array(
+    'nothing' => t('Nothing'),
+  );
+  $default_action = 'nothing';
+  if (empty($form_state['values']['mapper'])) {
+    $mapper = isset($importer) ? $importer->mapper : NULL;
+  }
+  else {
+    $mapper = $form_state['values']['mapper'];
+  }
+  if (isset($mapper)) {
+    $mapper = capx_cfe_load_by_machine_name($mapper, 'mapper');
+    $entity_type = $mapper->entity_type;
+    switch ($entity_type) {
+      case 'node':
+        $default_action = 'unpublish';
+        $action_options[$default_action] = t('Unpublish node');
+        break;
+
+      case 'user':
+        $default_action = 'block';
+        $action_options[$default_action] = t('Block user');
+        break;
+    }
+  }
+  // Adding this option here to keep meaningful order for the end user.
+  $action_options['delete'] = t('Delete');
+
+  $form['naming']['orphan_action'] = array(
+    '#title' => t('Action to perform on orphaned profiles'),
+    '#description' => t('Orphan profiles are profiles that are removed from the CAP API or from the importer configuration. Unpublished option only works on node entities and all other types will be left unchanged.'),
+    '#type' => "select",
+    '#options' => $action_options,
+    '#default_value' => $default_action,
+    '#prefix' => '<div id="orphan-action-wrapper">',
+    '#suffix' => '</div>',
   );
 
   // Cron Settings
@@ -1207,6 +1251,13 @@ function stanford_capx_importer_form($form, &$form_state, $importer = NULL) {
 }
 
 /**
+ * AJAX callback.
+ */
+function _stanford_capx_importer_form_mapper_ajax_callback($form, $form_state) {
+  return $form['naming']['orphan_action'];
+}
+
+/**
  * [stanford_capx_importer_machine_name_exits description]
  * @todo refactor this with the mapper_machine_name_exists function.
  * @param  [type] $name [description]
@@ -1267,6 +1318,7 @@ function stanford_capx_importer_form_submit($form, &$form_state) {
   $settings['workgroup'] = $values['workgroup'];
   $settings['sunet_id'] = $values['sunet_id'];
   $settings['cron_option'] = $values['cron_option'];
+  $settings['orphan_action'] = $values['orphan_action'];
 
   $importer->settings = $settings;
 
@@ -1697,18 +1749,6 @@ function stanford_capx_forms_config_settings($form, &$form_state) {
     '#type' => 'textfield',
     '#required' => TRUE,
     '#default_value' => variable_get("stanford_capx_batch_limit", 100),
-  );
-
-  $form['variables']['stanford_capx_orphan_action'] = array(
-    '#title' => t('Action to perform on orphaned profiles'),
-    '#description' => t('Orphan profiles are profiles that are removed from the CAP API or from the importer configuration. Unpublished option only works on node entities and all other types will be left unchanged.'),
-    '#type' => "select",
-    '#options' => array(
-      'nothing' => t("Nothing"),
-      'unpublish' => t('Unpublish - Nodes only'),
-      'delete' => t('Delete'),
-    ),
-    '#default_value' => variable_get('stanford_capx_orphan_action', 'unpublish'),
   );
 
   $form['submit'] = array(

--- a/stanford_capx.install
+++ b/stanford_capx.install
@@ -4,41 +4,16 @@
  */
 
 /**
- * Implements hook_install().
- */
-function stanford_capx_install() {
-  variable_set('stanford_capx_batch_limit', 100);
-}
-
-/**
- * Implements hook_enable().
- */
-function stanford_capx_enable() {
-  /*
-   *mymodule_cache_rebuild();
-   */
-  /* Your code here */
-}
-
-/**
- * Implements hook_disable().
- */
-function stanford_capx_disable() {
-  /*
-   *mymodule_cache_rebuild();
-   */
-  /* Your code here */
-}
-
-/**
  * Implements hook_uninstall().
  */
 function stanford_capx_uninstall() {
-
-  // @todo: Delete all the configuration entities and vars
   variable_del('stanford_capx_batch_limit');
-  variable_del('stanford_capx_orphan_action');
-
+  variable_del('stanford_capx_username');
+  variable_del('stanford_capx_password');
+  variable_del('stanford_capx_api_base_url');
+  variable_del('stanford_capx_api_auth_uri');
+  variable_del('stanford_capx_admin_messages');
+  variable_del('stanford_capx_token');
 }
 
 /**

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -272,9 +272,9 @@ function stanford_capx_cron() {
 
   // Call cron on all importers.
   $importers = CAPxImporter::loadAllImporters();
-  foreach ($importers as $key => $importer) {
+  foreach ($importers as $importer) {
     $entity_importer = CAPxImporter::loadEntityImporter($importer->getMachineName());
-    if ($entity_importer) {
+    if ($entity_importer && $entity_importer->valid()) {
       $entity_importer->cron();
     }
     else {


### PR DESCRIPTION
CAPX-107: Moved orphan handling to importer.

All entities now have "Nothing" and "Delete" actions.
Users have "Block user" action, nodes have "Unpublish" action.

How to test:
- Create importer and select "Action to perform on orphaned profiles" in "Configuration" section
- Import profiles for some organizatoin
- Add SUNet ID profile
- Run import again
- Remove SUNet ID profile
- Click "Check for orphans" link on created importer
- Confirm that selected action for orphans was fired
