### PR TITLE
CAPX-114: Added Etag invalidation of profiles affected by importer or mapper been saved.

### DIFF
--- a/includes/CAPx/Drupal/Entities/CFEntity.php
+++ b/includes/CAPx/Drupal/Entities/CFEntity.php
@@ -97,31 +97,4 @@ class CFEntity extends \Entity {
     return $this->machine_name;
   }
 
-  /**
-   * Invalidates Etag of imported profiles.
-   */
-  public function save() {
-    parent::save();
-
-    switch ($this->bundle()) {
-      case 'importer':
-        $importer = $this->identifier();
-        break;
-
-      case 'mapper':
-        $importers = CAPxImporter::loadImportersByMapper($this);
-        $importer = array();
-        foreach ($importers as $i) {
-          $importer[] = $i->identifier();
-        }
-
-        break;
-    }
-
-    db_update('capx_profiles')
-      ->condition('importer', $importer)
-      ->fields(array('etag' => 'invalidated'))
-      ->execute();
-  }
-
 }

--- a/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
@@ -158,7 +158,7 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
     // Get a list of all the profiles that are associated with this importer.
     $query = db_select("capx_profiles", 'capx')
       ->fields('capx', array('entity_type', 'entity_id', 'profile_id'))
-      ->condition('importer', $importer->getMachineName())
+      ->condition('importer', $importer->identifier())
       ->condition('sync', TRUE)
       ->orderBy('profile_id', 'ASC');
 
@@ -179,7 +179,7 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
     foreach ($chunk as $slice) {
       $batch['operations'][] = array(
         '\CAPx\Drupal\Importer\Orphans\EntityImporterOrphansBatch::batch',
-        array($importer->getMachineName(), $slice),
+        array($importer->identifier(), $slice),
       );
     }
 

--- a/stanford_capx.blocks.inc
+++ b/stanford_capx.blocks.inc
@@ -304,7 +304,7 @@ function stanford_capx_mapper_in_use_block() {
 
   $porters = array();
   foreach ($importers as $k => $importer) {
-    $porters[] = l(t("!title", array("!title" => $importer->title)), "admin/config/capx/importer/edit/" . $importer->getMachineName());
+    $porters[] = l(t("!title", array("!title" => $importer->title)), "admin/config/capx/importer/edit/" . $importer->identifier());
   }
 
   $output .= implode(", ", $porters);

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -1355,7 +1355,7 @@ function stanford_capx_admin_config_importer_delete($form, &$form_state, $machin
   // Add the machine name so we can do stuff with the importer later.
   $form['machine-name'] = array(
     '#type' => 'value',
-    '#value' => $importer->getMachineName(),
+    '#value' => $machine_name,
   );
 
   // Operations.

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -944,7 +944,7 @@ function stanford_capx_mapper_form_submit($form, $form_state) {
 
   $mapper->settings = $settings;
 
-  // New vs Edit
+  // New vs Edit.
   if (!empty($mapper->is_new)) {
     drupal_set_message(t('Congratulations, Your mapper has been created.'), 'status', FALSE);
   }
@@ -1291,6 +1291,7 @@ function stanford_capx_importer_form_submit($form, &$form_state) {
     drupal_set_message(t('Congratulations, Your importer has been created.'), 'status', FALSE);
   }
   else {
+    CAPx::invalidateEtags("importer", $importer);
     drupal_set_message(t("Your importer has been updated."), 'status', FALSE);
   }
 

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -273,13 +273,13 @@ function stanford_capx_cron() {
   // Call cron on all importers.
   $importers = CAPxImporter::loadAllImporters();
   foreach ($importers as $key => $importer) {
-    $entity_importer = CAPxImporter::loadEntityImporter($importer->getMachineName());
+    $entity_importer = CAPxImporter::loadEntityImporter($importer->identifier());
     if ($entity_importer) {
       $entity_importer->cron();
     }
     else {
       $vars = array(
-        '%name' => $importer->getMachineName(),
+        '%name' => $importer->identifier(),
       );
       watchdog('There was an issue loading the importer with %name machine name.', $vars, WATCHDOG_ERROR);
     }


### PR DESCRIPTION
CAPX-114: Added Etag invalidation of profiles affected by importer or mapper been saved.

How to test:
- Create 2 mappers
- Create 3 importers, using only created mappers and import some profiles
- Run "Update profiles now" on all importers
- Check log messages - you should see message "Etag matched. No processing happened." on all imported profiles
- Resave mapper used in 2 importers
- Check log messages - you should see that profiles was updated
- Resave importer that uses other mapper
- Check log messages - you should see that profiles was updated
