### PR TITLE
Soe 250

### DIFF
--- a/stanford_capx.install
+++ b/stanford_capx.install
@@ -8,11 +8,11 @@
  */
 function stanford_capx_install() {
   // Take our views and save them to the database.
-  module_load_include("inc", "stanford_capx", "stanford_capx.views_default");
-  $views = stanford_capx_views_default_views();
-  foreach ($views as $view) {
-    $view->save();
-  }
+  // module_load_include("inc", "stanford_capx", "stanford_capx.views_default");
+  // $views = stanford_capx_views_default_views();
+  // foreach ($views as $view) {
+  //   $view->save();
+  // }
 }
 
 /**
@@ -255,7 +255,7 @@ function stanford_capx_requirements($phase) {
   $requirements = array();
 
   switch ($phase) {
-    case 'install':
+    // case 'install':
     case 'runtime':
       // Ensure the modules' private files directory exists and is writable.
       if (!variable_get('file_private_path', FALSE)) {

--- a/stanford_capx.install
+++ b/stanford_capx.install
@@ -6,14 +6,7 @@
 /**
  * Implements hook_install().
  */
-function stanford_capx_install() {
-  // Take our views and save them to the database.
-  // module_load_include("inc", "stanford_capx", "stanford_capx.views_default");
-  // $views = stanford_capx_views_default_views();
-  // foreach ($views as $view) {
-  //   $view->save();
-  // }
-}
+function stanford_capx_install() {}
 
 /**
  * Implements hook_uninstall().
@@ -255,7 +248,6 @@ function stanford_capx_requirements($phase) {
   $requirements = array();
 
   switch ($phase) {
-    // case 'install':
     case 'runtime':
       // Ensure the modules' private files directory exists and is writable.
       if (!variable_get('file_private_path', FALSE)) {


### PR DESCRIPTION
- Remove the views save functionality on hook install so that stanford_capx can be declared as a dependency on an installation profile.
- Remove the install time requirement for private files and leave it at just a runtime message.
