### PR TITLE
Bug fix - Map tab listing only one Field Collection instead of all of the available ones.

### DIFF
--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -525,7 +525,7 @@ function stanford_capx_mapper_form_get_field_mapping_form($form, &$form_state, $
         $collection_container = $entity_machine_name . "-" . $bundle_machine_name . "-collections";
 
         // Fieldset for all fields on this entity -> bundle -> collection field
-        $form['field-mapping'][$collection_container] = array(
+        $form['field-mapping'][$collection_container][$field_machine_name] = array(
           '#type' => 'fieldset',
           '#title' => t('@name Field Collection', array("@name" => $field_machine_name)),
           '#description' => t(''),


### PR DESCRIPTION
When mapping Profiles to a content type that have multiple Field Collections, only the fields for one of the Field Collections were available for mapping.

It was caused by a bug in the loop that creates the fieldsets.
