### PR TITLE
BugFix - Changing approach on Orphans Lookup so it loads the profiles in smaller chunks

### DIFF
--- a/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
@@ -42,9 +42,17 @@ class LookupWorkgroupOrphans implements LookupInterface {
     // workgroup directly. Unfortunately, that means that we need to make
     // another request to the server for each work group.
 
-    $client->setLimit(99999);
+    // Setting limit of items per call to 100 so we don't overload the service.
+    $client->setLimit(100);
     $response = $client->api('profile')->search("privGroups", $groups);
     $results = $response['values'];
+
+    // Pull every existing page from CAPx one by one and merge to the results.
+    for ($page = 2; $page <= $response['totalPages']; $page++) {
+      $client->setPage($page);
+      $response = $client->api('profile')->search("privGroups", $groups);
+      $results = array_merge($results, $response['values']);
+    }
 
     drupal_alter('capx_orphan_profile_results', $results);
 

--- a/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
@@ -42,8 +42,10 @@ class LookupWorkgroupOrphans implements LookupInterface {
     // workgroup directly. Unfortunately, that means that we need to make
     // another request to the server for each work group.
 
-    // Setting limit of items per call to 100 so we don't overload the service.
-    $client->setLimit(100);
+    // Setting limit of items per call to use the batch limit variable
+    // so we don't overload the service.
+    $limit = variable_get('stanford_capx_batch_limit', 100);
+    $client->setLimit($limit);
     $response = $client->api('profile')->search("privGroups", $groups);
     $results = $response['values'];
 


### PR DESCRIPTION
The LookupWorkgroupOrphans class was using a page limit that is too high for the CAP API server and this was impacting the service in a way that we experienced outages when executing it for the GoGlobal website.

I've changed it to set the page limit to '100' (instead of '99999') and iterate through the pages querying the service several times merging the chunks into an array in order to keep the same behavior for the rest of the code.
