### PR TITLE
CAPX-213: Merge the connect and settings forms in to one.

### DIFF
--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -67,7 +67,6 @@ function stanford_capx_forms_connect_form_submit($form, &$form_state) {
     stanford_capx_organizations_sync();
   }
 
-
   // Endpoints.
   variable_set('stanford_capx_api_base_url', $form_state['values']['stanford_capx_api_base_url']);
   variable_set('stanford_capx_api_auth_uri', $form_state['values']['stanford_capx_api_auth_uri']);

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -64,7 +64,7 @@ function stanford_capx_forms_connect_form_submit($form, &$form_state) {
     // In order to get here we have to have a valid connection.
     // Lets get the org codes and schema.
     stanford_capx_schema_refresh();
-    // stanford_capx_organizations_sync();
+    stanford_capx_organizations_sync();
   }
 
 

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -13,83 +13,6 @@ use CAPx\Drupal\Util\CAPxMapper;
 use CAPx\Drupal\Util\CAPxImporter;
 use \Peekmo\JsonPath\JsonStore as JsonParser;
 
-// /////////////////////////////////////////////////////////////////////////////
-// CONNECT FORM
-// /////////////////////////////////////////////////////////////////////////////
-
-
-/**
- * Connection details form builder.
- */
-function stanford_capx_forms_connect_form($form, &$form_state) {
-
-  $username = CAPx::getAuthUsername();
-  $connection = CAPxConnection::testConnection();
-
-  $form['status'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Connection Status'),
-    '#collapsible' => TRUE,
-  );
-
-  $form['status']['status'] = array(
-    '#markup' => stanford_capx_connection_status_block(),
-  );
-
-  $form['auth'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Authorization'),
-    '#collapsible' => TRUE,
-    '#collapsed' => $connection->status,
-  );
-
-  $form['auth']['description'] = array(
-    '#markup' => t('Please enter your authentication information for the CAP API.'),
-  );
-
-  $form['auth']['stanford_capx_username'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Client ID:'),
-    '#default_value' => $username,
-    '#required' => TRUE,
-  );
-
-  $form['auth']['stanford_capx_password'] = array(
-    '#type' => 'password',
-    '#title' => t('Password:'),
-  );
-
-  $form['advanced'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Advanced'),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
-    '#description' => t('Advanced setting for CAP API and authentication URIs'),
-  );
-
-  $form['advanced']['stanford_capx_api_base_url'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Endpoint'),
-    '#description' => t('CAP API endpoint URI, only useful when switching between development/production environment.'),
-    '#default_value' => CAPx::getAPIEndpoint(),
-    '#required' => TRUE,
-  );
-
-  $form['advanced']['stanford_capx_api_auth_uri'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Authentication URI'),
-    '#description' => t('CAP API authentication URI.'),
-    '#default_value' => CAPx::getAuthEndpoint(),
-    '#required' => TRUE,
-  );
-
-  $form['submit'] = array(
-    '#type' => 'submit',
-    '#value' => t('Save connection settings'),
-  );
-
-  return $form;
-}
 
 /**
  * [stanford_capx_forms_connect_form_validate description]
@@ -104,46 +27,17 @@ function stanford_capx_forms_connect_form_validate($form, &$form_state) {
   $endpoint = $form_state['values']['stanford_capx_api_base_url'];
   $authpoint = $form_state['values']['stanford_capx_api_auth_uri'];
 
+  // Do not process a change on an empty password. Re-apply the password from
+  // the database because the system_form will save an empty value otherwise.
+  if (empty($password)) {
+    return;
+  }
+
   // If password changed validate auth.
-  if (!empty($password)) {
-    $auth_test = CAPxConnection::testAuthConnection($username, $password, $authpoint);
-    if (!$auth_test->status) {
-      form_set_error('stanford_capx_username', t('Could not authenticate with server. Invalid credentials. Please check your username and password.'));
-      form_set_error('stanford_capx_password');
-    }
-  }
-
-  // In case the end points change we need to get pass from db.
-  $password = !empty($password) ? $password : CAPx::getAuthPassword();
-
-  // If authpoint changed.
-  if ($authpoint !== "https://authz.stanford.edu/oauth/token") {
-
-    if (!isset($auth_test)) {
-      $auth_test = CAPxConnection::testAuthConnection($username, $password, $authpoint);
-    }
-
-    if (!$auth_test->status) {
-      form_set_error("stanford_capx_api_auth_uri", t("Please check your authorization url."));
-    }
-
-  }
-
-  // If endpoint changed.
-  if ($endpoint !== "https://api.stanford.edu") {
-
-    if (!isset($auth_test)) {
-      $auth_test = CAPxConnection::testAuthConnection($username, $password, $authpoint);
-    }
-
-    if (isset($auth_test->token)) {
-      $token = $auth_test->token;
-      $end_test = CAPxConnection::testApiConnection($token, $endpoint);
-      if (!$end_test->status) {
-        form_set_error("stanford_capx_api_base_url", t("Could not connect to API endpoint."));
-      }
-    }
-
+  $auth_test = CAPxConnection::testAuthConnection($username, $password, $authpoint);
+  if (!$auth_test->status) {
+    form_set_error('stanford_capx_username', t('Could not authenticate with server. Invalid credentials. Please check your username and password.'));
+    form_set_error('stanford_capx_password');
   }
 
 }
@@ -156,7 +50,7 @@ function stanford_capx_forms_connect_form_validate($form, &$form_state) {
  */
 function stanford_capx_forms_connect_form_submit($form, &$form_state) {
 
-  drupal_set_message(t('Configuration options were saved.'));
+  drupal_set_message(t("Configuration options saved."), "status");
 
   // Username and Pass.
   if (!empty($form_state['values']['stanford_capx_username'])
@@ -167,16 +61,16 @@ function stanford_capx_forms_connect_form_submit($form, &$form_state) {
     variable_set('stanford_capx_username', $username);
     variable_set('stanford_capx_password', $password);
 
+    // In order to get here we have to have a valid connection.
+    // Lets get the org codes and schema.
+    stanford_capx_schema_refresh();
+    // stanford_capx_organizations_sync();
   }
+
 
   // Endpoints.
   variable_set('stanford_capx_api_base_url', $form_state['values']['stanford_capx_api_base_url']);
   variable_set('stanford_capx_api_auth_uri', $form_state['values']['stanford_capx_api_auth_uri']);
-
-  // In order to get here we have to have a valid connection. Lets get the org codes
-  // and schema.
-  stanford_capx_schema_refresh();
-  stanford_capx_organizations_sync();
 }
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -1374,6 +1268,43 @@ function stanford_capx_importer_form($form, &$form_state, $importer = NULL) {
 }
 
 /**
+ * [stanford_capx_config_settings_data_sync_form description]
+ * @param  [type] $form       [description]
+ * @param  [type] $form_state [description]
+ * @return [type]             [description]
+ */
+function stanford_capx_config_settings_data_sync_form($form, $form_state) {
+  $form['orggroup'] = array(
+    '#type' => "fieldset",
+    '#title' => t("Organizations & Schema"),
+    '#description' => t("The CAPx module needs some information from the CAP API in order to function properly. Below are actions that require communication with the CAP API server and you must be connected before you can run these tasks."),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+  );
+
+  // Organizations.
+  $form['orggroup']['orgcodeinfo']['#markup'] = "<h3>Organizations</h3>";
+  $form['orggroup']['orgcodeinfo']['#markup'] .= "<p>" . t("Organization codes come from the CAP API and are saved to a taxonomy. This taxonomy powers the organization code autocomplete in the import section.") . "</p>";
+  $form['orggroup']['orgcodeinfo']['#markup'] .= "<p>" . t("Last sync: @date", array("@date" => variable_get('capx_last_orgs_sync', 'never'))) . "</p>";
+  $form['orggroup']['orgcodeinfo']['#markup'] .= "<p>" . t("View all organization codes: !link", array("!link" => l(t('Organization taxonomy'), 'admin/structure/taxonomy/capx_organizations'))) . "</p>";
+  $form['orggroup']['orgcodeinfo']['#markup'] .= "<p>" . l(t('Get organization data'), 'admin/config/capx/organizations/sync', array("attributes" => array('class' => array('btn button')), 'query' => array('destination' => current_path()))) . "</p>";
+
+  // Schema.
+  $form['orggroup']['schemainfo']['#markup'] = "<br /><h3>Schema Information</h3>";
+  $form['orggroup']['schemainfo']['#markup'] .= "<p>" . t("The CAP API provides a schema of the information available. The CAPx module needs this in order to power the data browser that is found on a mapping page.") . "</p>";
+  $form['orggroup']['schemainfo']['#markup'] .= "<p>" . t("Last sync: @date", array("@date" => variable_get('capx_last_schema_sync', 'never'))) . "</p>";
+  $form['orggroup']['submit'] = array(
+    '#type' => 'button',
+    '#value' => 'Get schema information',
+    '#op' => 'submit',
+    // '#element_validate' => array("stanford_capx_schema_refresh"), // Yes, I know this is abuse.
+  );
+
+  // $form['#submit'][] = "stanford_capx_schema_refresh";
+  return $form;
+}
+
+/**
  * AJAX callback.
  */
 function _stanford_capx_importer_form_mapper_ajax_callback($form, $form_state) {
@@ -1546,7 +1477,7 @@ function stanford_capx_admin_config_importer_delete($form, &$form_state, $machin
   $form['profile_action'] = array(
     '#type' => 'select',
     '#title' => t('What would you like to do with the items that are associated with this importer?'),
-//    '#description' => t('Perform an action on all of the items that have been imported by this importer.'),
+    //    '#description' => t('Perform an action on all of the items that have been imported by this importer.'),
     '#options' => array(
       'nothing' => t('Do nothing and leave the items as they are'),
       'delete' => t('Delete all of the items'),
@@ -1924,6 +1855,70 @@ function stanford_capx_schema_format_validation($schema = NULL) {
   return $formatted_schema;
 }
 
+/**
+ * Auth settings form. Was previously the connect page.
+ * @param  [type] $form        [description]
+ * @param  [type] &$form_state [description]
+ * @return [type]              [description]
+ */
+function stanford_capx_config_auth_settings_form($form, &$form_state) {
+  $username = CAPx::getAuthUsername();
+  $connection = CAPxConnection::testConnection();
+
+  $form['auth'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Authorization'),
+    '#collapsible' => TRUE,
+    '#collapsed' => $connection->status,
+    '#weight' => -10,
+  );
+
+  $form['auth']['description'] = array(
+    '#markup' => t('Please enter your authentication information for the CAP API. If you don\'t have these credentials yet you can !helpsu.', array('!helpsu' => l("File a HelpSU request", "https://helpsu.stanford.edu/helpsu/3.0/auth/helpsu-form?pcat=CAP_API&dtemplate=CAP-OAuth-Info"))),
+  );
+
+  $form['auth']['stanford_capx_username'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Client ID:'),
+    '#default_value' => $username,
+    '#required' => TRUE,
+  );
+
+  $form['auth']['stanford_capx_password'] = array(
+    '#type' => 'password',
+    '#title' => t('Password:'),
+  );
+
+  $form['advanced'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Advanced'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#description' => t('Advanced setting for CAP API and authentication URIs'),
+    '#access' => user_access("capx advanced administrator"),
+  );
+
+  $form['advanced']['stanford_capx_api_base_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Endpoint'),
+    '#description' => t('CAP API endpoint URI, only useful when switching between development/production environment.'),
+    '#default_value' => CAPx::getAPIEndpoint(),
+    '#required' => TRUE,
+  );
+
+  $form['advanced']['stanford_capx_api_auth_uri'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Authentication URI'),
+    '#description' => t('CAP API authentication URI.'),
+    '#default_value' => CAPx::getAuthEndpoint(),
+    '#required' => TRUE,
+  );
+
+  $form['#validate'][] = "stanford_capx_forms_connect_form_validate";
+  $form['#submit'][] = "stanford_capx_forms_connect_form_submit";
+
+  return $form;
+}
 
 /**
  * The global configuration settings for CAPx form builder.
@@ -1959,9 +1954,21 @@ function stanford_capx_config_settings_form($form, &$form_state) {
     '#default_value' => variable_get('stanford_capx_default_field_format', 'filtered_html'),
   );
 
-  $form = system_settings_form($form);
-  $form['actions']['submit']['#value'] = t("Save settings");
+  $form["#submit"][] = "stanford_capx_config_settings_form_submit";
+
   return $form;
+}
+
+/**
+ * Submit function for stanford_capx_config_settings_form
+ * @param  [type] $form        [description]
+ * @param  [type] &$form_state [description]
+ * @return [type]              [description]
+ */
+function stanford_capx_config_settings_form_submit($form, &$form_state) {
+  $values = $form_state["values"];
+  variable_set("stanford_capx_batch_limit", check_plain($values['stanford_capx_batch_limit']));
+  variable_set("stanford_capx_default_field_format", check_plain($values['stanford_capx_default_field_format']));
 }
 
 /**

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -69,7 +69,19 @@ function stanford_capx_permission() {
   return array(
     'administer capx' => array(
       'title' => t('Administer CAPx'),
-      'description' => t('Administer and Configure CAPx settings.'),
+      'description' => t('Administer and configure CAPx settings.'),
+    ),
+    'capx administer importers' => array(
+      'title' => t('Administer CAPx Importers'),
+      'description' => t('Administer and configure CAPx importers.'),
+    ),
+    'capx administer mappers' => array(
+      'title' => t('Administer CAPx Mappers'),
+      'description' => t('Administer and configure CAPx mappers.'),
+    ),
+    'capx advanced administrator' => array(
+      'title' => t('Administer Advanced CAPx settings'),
+      'description' => t('Administer and Ccnfigure CAPx advanced settings.'),
     ),
   );
 }
@@ -107,15 +119,6 @@ function stanford_capx_menu() {
     'page callback' => 'stanford_capx_admin_config',
     'access arguments' => array('administer capx'),
     'type' => MENU_NORMAL_ITEM,
-  );
-
-  // Connect page.
-  $items['admin/config/capx/connect'] = array(
-    'title' => 'Connect',
-    'page callback' => 'stanford_capx_admin_config_connect',
-    'access arguments' => array('administer capx'),
-    'type' => MENU_NORMAL_ITEM,
-    'weight' => -10,
   );
 
   // Settings Page.

--- a/stanford_capx.pages.inc
+++ b/stanford_capx.pages.inc
@@ -83,53 +83,36 @@ function stanford_capx_admin_config_settings() {
     drupal_set_message(t('The organization codes are not available. You should sync with the API now.'), 'warning', FALSE);
   }
 
-  // Organizations
-  // ---------------------------------------------------------------------------
+  $form = drupal_get_form("stanford_capx_admin_config_settings_get_all_the_forms_form");
 
-  $form = drupal_get_form("stanford_capx_config_settings_data_sync_form");
-  $output['content']["orgsform"] = $form;
-
-  // Settings form
-  // ---------------------------------------------------------------------------
-
-  $form = drupal_get_form('stanford_capx_config_settings_form');
-  $output["content"]["settingsform"] = $form;
+  $output['content']['submitbuttons'] = $form;
 
   return $output;
 }
 
 /**
- * [stanford_capx_config_settings_data_sync_form description]
+ * Returns all the forms that make up the settings page.
  * @param  [type] $form       [description]
  * @param  [type] $form_state [description]
  * @return [type]             [description]
  */
-function stanford_capx_config_settings_data_sync_form($form, $form_state) {
-  $form['orggroup'] = array(
-    '#type' => "fieldset",
-    '#title' => t("Organizations & Schema"),
-    '#description' => t("The CAPx module needs some information from the CAP API in order to function properly. Below are actions that require communication with the CAP API server and you must be connected before you can run these tasks."),
-    '#collapsible' => TRUE,
-    '#collapsed' => FALSE,
-  );
+function stanford_capx_admin_config_settings_get_all_the_forms_form($form, &$form_state) {
 
-  // Organizations.
-  $form['orggroup']['orgcodeinfo']['#markup'] = "<h3>Organizations</h3>";
-  $form['orggroup']['orgcodeinfo']['#markup'] .= "<p>" . t("Organization codes come from the CAP API and are saved to a taxonomy. This taxonomy powers the organization code autocomplete in the import section.") . "</p>";
-  $form['orggroup']['orgcodeinfo']['#markup'] .= "<p>" . t("Last sync: @date", array("@date" => variable_get('capx_last_orgs_sync', 'never'))) . "</p>";
-  $form['orggroup']['orgcodeinfo']['#markup'] .= "<p>" . t("View all organization codes: !link", array("!link" => l(t('Organization taxonomy'), 'admin/structure/taxonomy/capx_organizations'))) . "</p>";
-  $form['orggroup']['orgcodeinfo']['#markup'] .= "<p>" . l(t('Get organization data'), 'admin/config/capx/organizations/sync', array("attributes" => array('class' => array('btn button')), 'query' => array('destination' => current_path()))) . "</p>";
+  // $form = system_settings_form($form);
+  $form = stanford_capx_config_auth_settings_form($form, $form_state);
 
-  // Schema.
-  $form['orggroup']['schemainfo']['#markup'] = "<br /><h3>Schema Information</h3>";
-  $form['orggroup']['schemainfo']['#markup'] .= "<p>" . t("The CAP API provides a schema of the information available. The CAPx module needs this in order to power the data browser that is found on a mapping page.") . "</p>";
-  $form['orggroup']['schemainfo']['#markup'] .= "<p>" . t("Last sync: @date", array("@date" => variable_get('capx_last_schema_sync', 'never'))) . "</p>";
-  $form['orggroup']['submit'] = array(
+  $connection = CAPxConnection::testConnection();
+  if ($connection->status) {
+    $form = stanford_capx_config_settings_form($form, $form_state);
+    $form = stanford_capx_config_settings_data_sync_form($form, $form_state);
+  }
+
+
+  $form['actions']['submit'] = array(
+    '#value' => t("Save settings"),
     '#type' => 'submit',
-    '#value' => 'Get schema information',
-    '#op' => 'submit',
   );
-  $form['#submit'][] = "stanford_capx_schema_refresh";
+
   return $form;
 }
 


### PR DESCRIPTION
# DO NOT MERGE

---

Please review but do not merge.

Merges the two forms in to one cohesive form.
- Does not display configuration options until connection has been made
- Syncs orgs and schema on connect
- Buttons to manually sync orgs and schema re-worked
- Submit handlers changed.

To test: 
- Install this branch from scratch in a new site. 
- Go to settings page.
- Enter authentication credentials and save.
- Change other configuration options and save.
