### PR TITLE
CAPX-233: Prevents orphan processing when response from API is false

### DIFF
--- a/includes/CAPx/APILib/AbstractAPILib.php
+++ b/includes/CAPx/APILib/AbstractAPILib.php
@@ -196,6 +196,7 @@ abstract class AbstractAPILib implements AbstractAPILibInterface {
     }
 
     // Build and make the request.
+    $response = FALSE;
     try {
 
       $response = $client->get($endpoint, $options);

--- a/includes/CAPx/Drupal/Importer/Orphans/Comparisons/CompareWorkgroupsSunet.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/Comparisons/CompareWorkgroupsSunet.php
@@ -37,7 +37,7 @@ class CompareWorkgroupsSunet implements ComparisonInterface {
     $sunetOptions = array_map('trim', $sunetOptions);
 
     foreach ($orphans['privGroups'] as $index => $profileId) {
-      if (in_array($sunetIds[$profileId], $sunetOptions)) {
+      if (isset($sunetIds[$profileId]) && in_array($sunetIds[$profileId], $sunetOptions)) {
         // If the sunet code is found in the sunet id list option then the
         // profile is not an orphan and we need to unset it from the orphans.
         unset($orphans["orgCodes"][$index]);

--- a/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php
@@ -100,6 +100,13 @@ class EntityImporterOrphans implements ImporterOrphansInterface {
     // Make one request to the server for the profile information to check for
     // profiles that no longer exist on the API.
     $response = $client->api('profile')->search("ids", $profiles);
+
+    // Fail if the response from the server was not successful.
+    if (!$response || !is_array($response) || !isset($response['values'])) {
+      watchdog("EntityImporterOrphans", "Client response was false. Possible connectivity issue. Stopped orphan processing.", array(), WATCHDOG_WARNING);
+      return;
+    }
+
     $results = $response['values'];
 
     // Allow those to alter this set.

--- a/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupMissingFromSunetList.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupMissingFromSunetList.php
@@ -28,6 +28,7 @@ class LookupMissingFromSunetList implements LookupInterface {
       return $orphans;
     }
 
+    $orphans['uids'] = array();
     $results = $orphaner->getResults();
     $profiles = $orphaner->getProfiles();
     $orphans = $orphaner->getOrphans();

--- a/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupOrgOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupOrgOrphans.php
@@ -43,6 +43,7 @@ class LookupOrgOrphans implements LookupInterface {
 
     $profiles = $orphaner->getProfiles();
     $myOrphans = array();
+    $orphans['orgCodes'] = array();
 
     $keyTids = array();
     $codes = explode(",", $options['organization']);

--- a/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
@@ -34,6 +34,7 @@ class LookupWorkgroupOrphans implements LookupInterface {
     $client = $orphaner->getClient();
     $profiles = $orphaner->getProfiles();
     $groups = explode(",", $options['workgroup']);
+    $orphans['privGroups'] = array();
 
     // Flip the profileIds so that the profile array is keyed.
     $profiles = array_flip($profiles);


### PR DESCRIPTION
# CAPX-233

Ready for review.

This also fixes an issue where orphans were not being adopted. 

_To test:_
- Install a JSA website
- Check out the 2.x branch
- Create an importer and import a bunch of people 
- Disconnect your internet
- Run the orphan check through the UI or cron
- See orphans show up
- Set all the orphans back to "not orphaned'" in the database
- Check out this branch
- Run the orphan check through the UI or cron
- See no orphans created
- Party
