### PR TITLE
HSDO-641 #Initial structure & functionality of capx tampers

### DIFF
--- a/includes/CAPx/Drupal/Mapper/EntityMapper.php
+++ b/includes/CAPx/Drupal/Mapper/EntityMapper.php
@@ -35,6 +35,7 @@ class EntityMapper extends MapperAbstract {
     // Always attach the profileId to the entity
     $raw = $entity->value();
     $raw->capx['profileId'] = $data['profileId'];
+    $raw->capxMapper = $this;
     $entity->set($raw);
 
     // Store this for later.
@@ -100,6 +101,7 @@ class EntityMapper extends MapperAbstract {
     /** @var \EntityDrupalWrapper $entity */
     $entity = $this->getEntity();
     $error = FALSE;
+    $d = $data;
 
     // Loop through each field and run a field processor on it.
     foreach ($config['fields'] as $fieldName => $remoteDataPaths) {
@@ -111,7 +113,7 @@ class EntityMapper extends MapperAbstract {
         if ($fieldInfoInstance) {
           $info = array();
 
-          drupal_alter('capx_pre_map_field', $entity, $fieldName, $remoteDataPaths);
+          drupal_alter('capx_pre_map_field', $entity, $fieldName, $remoteDataPaths, $data);
 
           // Allow just one path as a string.
           // @todo For data structures like files we shouldn't convert data path to array.
@@ -175,6 +177,7 @@ class EntityMapper extends MapperAbstract {
           drupal_alter('capx_post_map_field', $entity, $fieldName);
         }
       }
+      $data = $d;
     }
 
     // Set the entity again for changes.
@@ -205,6 +208,7 @@ class EntityMapper extends MapperAbstract {
 
     // Loop through each property and run a property processor on it.
     foreach ($config['properties'] as $propertyName => $remoteDataPath) {
+      drupal_alter('capx_pre_property_set', $entity, $data, $propertyName);
       try {
         $info = $this->getRemoteDataByJsonPath($data, $remoteDataPath);
       }

--- a/includes/CAPx/Drupal/Processors/PropertyProcessors/PropertyProcessorAbstract.php
+++ b/includes/CAPx/Drupal/Processors/PropertyProcessors/PropertyProcessorAbstract.php
@@ -34,8 +34,6 @@ abstract class PropertyProcessorAbstract implements PropertyProcessorInterface {
 
     $data = is_array($data) ? array_shift($data) : $data;
 
-    drupal_alter('capx_pre_property_set', $entity, $data, $propertyName);
-
     if (empty($data)) {
       // @todo Do we really need to log this?
       $this->logIssue(new \Exception(t('Got empty property value.')));

--- a/modules/capx_tamper/CapxTamper.inc
+++ b/modules/capx_tamper/CapxTamper.inc
@@ -26,10 +26,10 @@ class CapxTamper {
    * @param \CAPx\Drupal\Entities\CFEntity $mapper
    *   Mapper in use.
    */
-  public function __construct(CFEntity $mapper) {
+  public function __construct(CFEntity $mapper, CapxTamperParser $parser, CapxTamperProcessor $processor) {
     $this->mapper = $mapper;
-    $this->parser = new CapxTamperParser();
-    $this->processor = new CapxTamperProcessor($mapper);
+    $this->parser = $parser;
+    $this->processor = $processor;
   }
 
 }

--- a/modules/capx_tamper/CapxTamper.inc
+++ b/modules/capx_tamper/CapxTamper.inc
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @file
+ * CAPx Tamper classes to fake feeds importer.
+ */
+
+use \CAPx\Drupal\Entities\CFEntity;
+
+/**
+ * Class CapxTamper.
+ */
+class CapxTamper {
+
+  /**
+   * Mapper to use for processing.
+   *
+   * @var CFEntity
+   */
+  public $mapper;
+  public $parser;
+  public $processor;
+
+  /**
+   * CapxTamper constructor.
+   *
+   * @param \CAPx\Drupal\Entities\CFEntity $mapper
+   *   Mapper in use.
+   */
+  public function __construct(CFEntity $mapper) {
+    $this->mapper = $mapper;
+    $this->parser = new CapxTamperParser();
+    $this->processor = new CapxTamperProcessor($mapper);
+  }
+
+}
+
+/**
+ * Class CapxTamperParser.
+ */
+class CapxTamperParser {
+
+  /**
+   * Simulates FeedsCSVParser::getMappingSources().
+   *
+   * @return bool
+   *   Similar to FeedsCSVParser
+   */
+  public function getMappingSources() {
+    return FALSE;
+  }
+
+}
+
+/**
+ * Class CapxTamperProcessor.
+ */
+class CapxTamperProcessor {
+
+  /**
+   * Mapper to use for processing.
+   *
+   * @var CFEntity
+   */
+  public $mapper;
+
+  /**
+   * CapxTamperProcessor constructor.
+   *
+   * @param CFEntity $mapper
+   *   CAPx Mapper to use.
+   */
+  public function __construct(CFEntity $mapper) {
+    $this->mapper = $mapper;
+  }
+
+  /**
+   * Passes the available sources & targets.
+   *
+   * @return array
+   *   Available sources.
+   */
+  public function getMappings() {
+    $mapper_sources = capx_tamper_get_mapper_sources($this->mapper);
+    $sources = array();
+    foreach ($mapper_sources as $path => $targets) {
+      $sources[] = array(
+        'source' => $path,
+        'target' => implode(':', $targets),
+        'unique' => FALSE,
+        'language' => LANGUAGE_NONE,
+      );
+    }
+    return $sources;
+  }
+
+}

--- a/modules/capx_tamper/CapxTamper.inc
+++ b/modules/capx_tamper/CapxTamper.inc
@@ -82,10 +82,10 @@ class CapxTamperProcessor {
   public function getMappings() {
     $mapper_sources = capx_tamper_get_mapper_sources($this->mapper);
     $sources = array();
-    foreach ($mapper_sources as $path => $targets) {
+    foreach ($mapper_sources as $target => $path) {
       $sources[] = array(
         'source' => $path,
-        'target' => implode(':', $targets),
+        'target' => $target,
         'unique' => FALSE,
         'language' => LANGUAGE_NONE,
       );

--- a/modules/capx_tamper/README.md
+++ b/modules/capx_tamper/README.md
@@ -1,0 +1,20 @@
+# Stanford CAPx Tampers
+#### Version 2.0-dev
+
+CAPx Tampers provide the option to alter the data from the API before saving it to a profile. Much of this functionality is inspired by the feeds_tamper module and additional help can be found at that resource.
+
+## Installation
+
+Install this module like [any other Drupal module](https://www.drupal.org/documentation/install/modules-themes/modules-7).
+
+## Configuration
+
+When enabled please first create a mapper. After the mapper has been created there will be an additional link titled 'Tampers' under the actions in the mapper list page. (/admin/config/capx/mappers). Click on the 'Tampers' link and choose from the options available to create your tampers.
+
+## Troubleshooting
+
+If you are experiencing issues with this module try reverting the feature first. If you are still experiencing issues try posting an issue on the GitHub issues page.
+
+## Contribution / Collaboration
+
+You are welcome to contribute functionality, bug fixes, or documentation to this module. If you would like to suggest a fix or new functionality you may add a new issue to the GitHub issue queue or you may fork this repository and submit a pull request. For more help please see [GitHub's article on fork, branch, and pull requests](https://help.github.com/articles/using-pull-requests)

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -2,9 +2,19 @@
 /**
  * @file
  * CAPx Tamper Forms.
+ *
+ * Mostly taken from feeds_tamper_ui.admin.inc.
  */
 
-
+/**
+ * Shows the current tampers in table format for the given CAPx Mapper.
+ *
+ * @param string $mapper_id
+ *   Machine name of the mapper to apply tamper to.
+ *
+ * @return array
+ *   Renderable array.
+ */
 function capx_tamper_list($mapper_id) {
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   $mapper = capx_tamper_check_mapper($mapper_id);
@@ -36,13 +46,13 @@ function capx_tamper_list($mapper_id) {
     $rows = array();
 
     $instance = field_info_instance($mapper->entity_type, $field_key, $mapper->bundle_type);
-
-    foreach (capx_tamper_get_tampers($mapper_id, $field_key) as $tamper) {
-      $edit_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper['id']}/edit";
-      $delete_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper['id']}/delete";
-      $plugin = feeds_tamper_get_plugin($tamper['plugin_id']);
+    $conditions = array('mapper' => $mapper_id, 'source' => $field_key);
+    foreach (capx_tamper_load_tampers($conditions) as $tamper) {
+      $edit_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/edit";
+      $delete_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/delete";
+      $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
       $rows[] = array(
-        $tamper['description'],
+        $tamper->description,
         $plugin['name'],
         l(t('Edit'), $edit_url) . ' | ' . l(t('Delete'), $delete_url),
         '&#x2705',
@@ -79,6 +89,9 @@ function capx_tamper_list($mapper_id) {
   return $output;
 }
 
+/**
+ * Tamper add form.
+ */
 function capx_tamper_add($form, &$form_state, $mapper_id, $source) {
   drupal_set_title(t('Add Tamper Plugin'));
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
@@ -160,6 +173,9 @@ function capx_tamper_add($form, &$form_state, $mapper_id, $source) {
   return $form;
 }
 
+/**
+ * Tamper add form validation
+ */
 function capx_tamper_add_validate($form, &$form_state) {
   if ($form_state['triggering_element']['#value'] == t('Add')) {
     if (capx_tamper_machine_name_callback($form_state['values']['id'], $form, $form_state)) {
@@ -178,6 +194,9 @@ function capx_tamper_add_validate($form, &$form_state) {
   unset($form_state['input']['settings']);
 }
 
+/**
+ * Tamper add form submit to save to table.
+ */
 function capx_tamper_add_submit($form, &$form_state) {
   if ($form_state['triggering_element']['#value'] == t('Add')) {
     /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
@@ -187,15 +206,16 @@ function capx_tamper_add_submit($form, &$form_state) {
       $form_state['source'],
       $form_state['values']['id'],
     ));
-    $tamper = array(
-      'id' => $id,
-      'mapper' => $mapper->identifier(),
-      'source' => $form_state['source'],
-      'plugin_id' => $form_state['values']['plugin_id'],
-      'settings' => $form_state['values']['settings'],
-      'weight' => '0',
-      'description' => $form_state['values']['description'],
-    );
+
+    $tamper = new stdClass();
+    $tamper->id = $id;
+    $tamper->mapper = $mapper->identifier();
+    $tamper->source = $form_state['source'];
+    $tamper->plugin_id = $form_state['values']['plugin_id'];
+    $tamper->settings = $form_state['values']['settings'];
+    $tamper->weight = '0';
+    $tamper->description = $form_state['values']['description'];
+
 
     capx_tamper_save_instance($tamper);
     $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
@@ -209,14 +229,16 @@ function capx_tamper_add_submit($form, &$form_state) {
   $form_state['rebuild'] = TRUE;
 }
 
-
+/**
+ * Checks for existing machine name.
+ */
 function capx_tamper_machine_name_callback($id, $form, &$form_state) {
   $id = implode('-', array(
     $form_state['mapper']->identifier(),
     $form_state['source'],
     $form_state['values']['id'],
   ));
-  return capx_tamper_load_tamper($id);
+  return capx_tamper_load_tampers(array('id' => $id));
 }
 
 
@@ -227,13 +249,16 @@ function capx_tamper_ajax_callback($form, $form_state) {
   return $form['plugin'];
 }
 
+/**
+ * Confirmation of delete tamper.
+ */
 function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
   $mapper = capx_tamper_check_mapper($mapper_id);
 
-  $tamper = capx_tamper_load_tamper($tamper_id);
+  $tamper = reset(capx_tamper_load_tampers(array('id' => $tamper_id)));
   $form_state['tamper'] = $tamper;
   $form_state['mapper'] = $mapper;
-  $question = t('Would you really like to delete the plugin @instance?', array('@instance' => $instance->description));
+  $question = t('Would you really like to delete the plugin @instance?', array('@instance' => $tamper->description));
   $button_label = t('Delete');
 
   return confirm_form(
@@ -245,6 +270,9 @@ function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
   );
 }
 
+/**
+ * Tamper delete form submit.
+ */
 function capx_tamper_delete_submit($form, &$form_state) {
   $tamper = $form_state['tamper'];
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
@@ -253,13 +281,16 @@ function capx_tamper_delete_submit($form, &$form_state) {
   capx_tamper_delete_instance($tamper);
 
   drupal_set_message(t('The plugin %plugin has been deleted from %source.', array(
-    '%plugin' => $tamper['description'],
-    '%source' => $tamper['source'],
+    '%plugin' => $tamper->description,
+    '%source' => $tamper->source,
   )));
 
   $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
 }
 
+/**
+ * Checks for valid capx mapper and throws 404 if invalid.
+ */
 function capx_tamper_check_mapper($mapper_id) {
   $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
   if (!$mapper) {
@@ -269,23 +300,26 @@ function capx_tamper_check_mapper($mapper_id) {
   return $mapper;
 }
 
+/**
+ * Tamper plugin edit form.
+ */
 function capx_tamper_edit($form, &$form_state, $mapper_id, $tamper_id) {
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   $mapper = capx_tamper_check_mapper($mapper_id);
   $form_state['mapper'] = $mapper;
-  $tamper = capx_tamper_load_tamper($tamper_id);
+  $tamper = reset(capx_tamper_load_tampers(array('id' => $tamper_id)));
   $form_state['tamper'] = $tamper;
 
-  drupal_set_title(t('Edit !title', array('!title' => $tamper['description'])));
+  drupal_set_title(t('Edit !title', array('!title' => $tamper->description)));
 
-  $plugin = feeds_tamper_get_plugin($tamper['plugin_id']);
+  $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
   $form['#tree'] = TRUE;
 
   $form['description'] = array(
     '#title' => t('Description'),
     '#type' => 'textfield',
     '#description' => t('A useful description of what this plugin is doing.'),
-    '#default_value' => $tamper['description'],
+    '#default_value' => $tamper->description,
   );
   $form['settings'] = array(
     '#title' => t('Configure @plugin', array('@plugin' => $plugin['name'])),
@@ -293,7 +327,7 @@ function capx_tamper_edit($form, &$form_state, $mapper_id, $tamper_id) {
     '#tree' => TRUE,
   );
   $importer = new stdClass();
-  $form['settings'] += $plugin['form']($importer, $tamper['source'], $tamper['settings'], $form_state);
+  $form['settings'] += $plugin['form']($importer, $tamper->source, $tamper->settings, $form_state);
 
   $form['save'] = array(
     '#type' => 'submit',
@@ -305,15 +339,29 @@ function capx_tamper_edit($form, &$form_state, $mapper_id, $tamper_id) {
   return $form;
 }
 
+/**
+ * Tamper edit validation.
+ */
+function capx_tamper_edit_validate($form, &$form_state) {
+  $plugin_id = $form_state['instance']->plugin_id;
+  $plugin = feeds_tamper_get_plugin($plugin_id);
+  if ($plugin['validate']) {
+    $plugin['validate']($form_state['values']['settings']);
+  }
+}
+
+/**
+ * Tamper plugin edit submit.
+ */
 function capx_tamper_edit_submit($form, &$form_state) {
   $mapper = $form_state['mapper'];
   $tamper = $form_state['tamper'];
   if (isset($form_state['values']['settings'])) {
-    $tamper['settings'] = $form_state['values']['settings'];
+    $tamper->settings = $form_state['values']['settings'];
   }
-  $tamper['description'] = $form_state['values']['description'];
+  $tamper->description = $form_state['values']['description'];
 
   capx_tamper_save_instance($tamper);
-  drupal_set_message(t('The plugin %plugin has been updated.', array('%plugin' => $tamper['description'])));
+  drupal_set_message(t('The plugin %plugin has been updated.', array('%plugin' => $tamper->description)));
   $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
 }

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -54,52 +54,68 @@ function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = 
 
   $sources = capx_tamper_get_mapper_sources($mapper);
 
-  foreach ($sources as $path => $targets) {
+  foreach ($sources as $target => $path) {
     $path_tampers = capx_tamper_load_tampers(array(
       'mapper' => $mapper->getMachineName(),
-      'source' => $path,
+      'target' => $target,
     ));
 
-    $form['tampers'][$path] = array();
+    if ($instance = field_info_instance($mapper->entity_type, $target, $mapper->bundle_type)) {
+      $target_label = $instance['label'];
+    }
+    else {
+      $target_label = ucwords($target);
+    }
+
+    $form['tampers'][$target] = array(
+      'caption' => array(
+        '#markup' => t('!from -> !to', array(
+          '!from' => $path,
+          '!to' => $target_label,
+        )),
+      ),
+    );
 
     foreach ($path_tampers as $tamper) {
       $edit_url = CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/{$tamper->id}/edit";
       $delete_url = CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/{$tamper->id}/delete";
-
-      $edit = l(t('Edit'), $edit_url);
-      $edit .= " | " . l(t('Delete'), $delete_url);
-
+      $operations = l(t('Edit'), $edit_url) . " | " . l(t('Delete'), $delete_url);
       $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
-      $form['tampers'][$path][$tamper->id]['description'] = array(
+
+      $form['tampers'][$target][$tamper->id]['description'] = array(
         '#markup' => t($tamper->description),
       );
-      $form['tampers'][$path][$tamper->id]['plugin_id'] = array(
+      $form['tampers'][$target][$tamper->id]['plugin_id'] = array(
         '#markup' => t($plugin['name']),
       );
-      $form['tampers'][$path][$tamper->id]['operations'] = array(
-        '#markup' => $edit,
+      $form['tampers'][$target][$tamper->id]['operations'] = array(
+        '#markup' => $operations,
       );
-      $form['tampers'][$path][$tamper->id]['weight'] = array(
+      $form['tampers'][$target][$tamper->id]['weight'] = array(
         '#type' => 'weight',
         '#title' => t('Weight'),
         '#default_value' => $tamper->weight,
         '#attributes' => array(
-          'class' => array(capx_tamper_table_id($path) . '-weight'),
+          'class' => array(capx_tamper_table_id($target) . '-weight'),
         ),
       );
-      $form['tampers'][$path][$tamper->id]['enabled'] = array(
+      $form['tampers'][$target][$tamper->id]['enabled'] = array(
         '#type' => 'checkbox',
         '#title' => t('Enabled'),
         '#default_value' => !$tamper->disabled,
       );
     }
+    $form['tampers'][$target]['add_link'] = array(
+      '#markup' => l(t('Add Plugin'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/add/" . bin2hex("$target:$path")),
+      '#prefix' => '<ul class="feeds-tamper-add action-links"><li>',
+      '#suffix' => '</li></ul>',
+    );
   }
 
   $form['save'] = array(
     '#type' => 'submit',
     '#value' => t('Save'),
   );
-
   $form['#attached']['css'] = array(drupal_get_path('module', 'capx_tamper') . '/css/capx_tamper.css');
   return $form;
 }
@@ -109,7 +125,7 @@ function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = 
  */
 function capx_tamper_list_form_submit($form, &$form_state) {
   $disabled = variable_get('capx_tamper_disabled', array());
-  foreach ($form_state['values']['tampers'] as $path => $tampers) {
+  foreach ($form_state['values']['tampers'] as $tampers) {
     foreach ($tampers as $id => $settings) {
       $tamper = capx_tamper_load_tampers(array('id' => $id));
       $tamper = reset($tamper);
@@ -139,15 +155,18 @@ function capx_tamper_list_form_submit($form, &$form_state) {
  * @return array
  *   Form render array.
  */
-function capx_tamper_add_form($form, &$form_state, CFEntity $mapper, $source) {
-  drupal_set_title(t('Add Tamper Plugin'));
+function capx_tamper_add_form($form, &$form_state, CFEntity $mapper, $target_source) {
+  list($target, $source) = explode(':', hex2bin($target_source), 2);
+
+  drupal_set_title(t('Add Tamper Plugin for !from -> !to', array(
+    '!from' => $source,
+    '!to' => $target,
+  )));
   capx_tamper_breadcrumb($mapper, TRUE);
-  $source = hex2bin($source);
 
   $form_state['mapper'] = $mapper;
   $form_state['source'] = $source;
-
-  $form['#attached']['css'][] = drupal_get_path('module', 'capx_tamper') . '/css/capx_tamper.css';
+  $form_state['target'] = $target;
 
   // Build plugin select list.
   $capx_tamper_plugins = feeds_tamper_get_plugins();
@@ -222,6 +241,8 @@ function capx_tamper_add_form($form, &$form_state, CFEntity $mapper, $source) {
     '#value' => t('Add'),
   );
 
+  $form['#attached']['css'][] = drupal_get_path('module', 'capx_tamper') . '/css/capx_tamper.css';
+
   return $form;
 }
 
@@ -266,6 +287,7 @@ function capx_tamper_add_form_submit($form, &$form_state) {
     $id = implode('-', array(
       $mapper->identifier(),
       $form_state['source'],
+      $form_state['target'],
       $form_state['values']['id'],
     ));
 
@@ -273,6 +295,7 @@ function capx_tamper_add_form_submit($form, &$form_state) {
     $tamper->id = $id;
     $tamper->mapper = $mapper->identifier();
     $tamper->source = $form_state['source'];
+    $tamper->target = $form_state['target'];
     $tamper->plugin_id = $form_state['values']['plugin_id'];
     $tamper->settings = $form_state['values']['settings'];
     $tamper->weight = '0';
@@ -404,15 +427,8 @@ function capx_tamper_delete_form($form, &$form_state, CFEntity $mapper, $tamper_
   $tamper = reset($tamper);
   $form_state['tamper'] = $tamper;
   $form_state['mapper'] = $mapper;
-
-  if ($tamper->export_type & EXPORT_IN_CODE) {
-    $question = t('Would you really like to revert the plugin @tamper?', array('@tamper' => $tamper->description));
-    $button_label = t('Revert');
-  }
-  else {
-    $question = t('Would you really like to delete the plugin @tamper?', array('@tamper' => $tamper->description));
-    $button_label = t('Delete');
-  }
+  $question = t('Would you really like to delete the plugin @tamper?', array('@tamper' => $tamper->description));
+  $button_label = t('Delete');
 
   return confirm_form(
     $form,
@@ -431,20 +447,10 @@ function capx_tamper_delete_form_submit($form, &$form_state) {
   /** @var CFEntity $mapper */
   $mapper = $form_state['mapper'];
   capx_tamper_delete_instance($tamper);
-
-  switch ($tamper->export_type) {
-    case EXPORT_IN_DATABASE:
-      drupal_set_message(t('The plugin %plugin has been deleted from %source.', array(
-        '%plugin' => $tamper->description,
-        '%source' => $tamper->source,
-      )));
-      break;
-
-    case EXPORT_IN_CODE | EXPORT_IN_DATABASE:
-      drupal_set_message(t('The plugin %plugin has been reverted.', array('%plugin' => $tamper->description)));
-      break;
-  }
-
+  drupal_set_message(t('The plugin %plugin has been deleted from %source.', array(
+    '%plugin' => $tamper->description,
+    '%source' => $tamper->source,
+  )));
   $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
 }
 
@@ -465,6 +471,7 @@ function capx_tamper_machine_name_callback($id, $form, &$form_state) {
   $check_id = implode('-', array(
     $form_state['mapper']->identifier(),
     $form_state['source'],
+    $form_state['target'],
     $form_state['values']['id'],
   ));
   return capx_tamper_load_tampers(array('id' => $check_id));

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -69,7 +69,7 @@ function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = 
 
     $form['tampers'][$target] = array(
       'caption' => array(
-        '#markup' => t('!from -> !to', array(
+        '#markup' => t('!to <- !from', array(
           '!from' => $path,
           '!to' => $target_label,
         )),
@@ -158,7 +158,7 @@ function capx_tamper_list_form_submit($form, &$form_state) {
 function capx_tamper_add_form($form, &$form_state, CFEntity $mapper, $target_source) {
   list($target, $source) = explode(':', hex2bin($target_source), 2);
 
-  drupal_set_title(t('Add Tamper Plugin for !from -> !to', array(
+  drupal_set_title(t('Add Tamper Plugin for !to <- !from', array(
     '!from' => $source,
     '!to' => $target,
   )));
@@ -233,7 +233,10 @@ function capx_tamper_add_form($form, &$form_state, CFEntity $mapper, $target_sou
     '#type' => 'fieldset',
     '#tree' => TRUE,
   );
-  $importer = new CapxTamper($mapper);
+
+  $parser = new CapxTamperParser();
+  $processor = new CapxTamperProcessor($mapper);
+  $importer = new CapxTamper($mapper, $parser, $processor);
 
   $form['plugin']['settings'] += $plugin['form']($importer, $source, array(), $form_state);
   $form['add'] = array(
@@ -356,7 +359,11 @@ function capx_tamper_edit_form($form, &$form_state, CFEntity $mapper, $tamper_id
     '#type' => 'fieldset',
     '#tree' => TRUE,
   );
-  $importer = new CapxTamper($mapper);
+
+  $parser = new CapxTamperParser();
+  $processor = new CapxTamperProcessor($mapper);
+  $importer = new CapxTamper($mapper, $parser, $processor);
+
   $form['settings'] += $plugin['form']($importer, $tamper->source, $tamper->settings, $form_state);
 
   $form['save'] = array(

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * CAPx Tamper Forms.
@@ -13,7 +14,7 @@ use \CAPx\Drupal\Entities\CFEntity;
  *
  * @param string $action
  *   Add, Edit, or Delete.
- * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ * @param CFEntity $mapper
  *   CAPx Mapper.
  * @param string|null $source
  *   JSON Path string.
@@ -21,7 +22,7 @@ use \CAPx\Drupal\Entities\CFEntity;
  * @return array
  *   Form render array.
  */
-function capx_tamper_build_form($action, $mapper, $source = NULL) {
+function capx_tamper_build_form($action, CFEntity $mapper, $source = NULL) {
   $form_name = "capx_tamper_{$action}_form";
   return drupal_get_form($form_name, $mapper, $source);
 }
@@ -29,8 +30,14 @@ function capx_tamper_build_form($action, $mapper, $source = NULL) {
 /**
  * Shows the current tampers in table format for the given CAPx Mapper.
  *
- * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State.
+ * @param CFEntity $mapper
  *   Mapper to apply tamper to.
+ * @param null $source
+ *   Null source since we want all sources.
  *
  * @return array
  *   Renderable array.
@@ -106,6 +113,11 @@ function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = 
           'class' => array(capx_tamper_table_id($path) . '-weight'),
         ),
       );
+      $form['tampers'][$path][$tamper->id]['enabled'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Enabled'),
+        '#default_value' => !$tamper->disabled,
+      );
     }
   }
 
@@ -114,24 +126,37 @@ function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = 
     '#value' => t('Save'),
   );
 
+  $form['#attached']['css'] = array(drupal_get_path('module', 'capx_tamper') . '/css/capx_tamper.css');
   return $form;
 }
 
+/**
+ * List form submit. Sets weights & enabled/disabled.
+ */
 function capx_tamper_list_form_submit($form, &$form_state) {
+  $disabled = variable_get('capx_tamper_disabled', array());
   foreach ($form_state['values']['tampers'] as $path => $tampers) {
-    foreach ($tampers as $id => $weight) {
+    foreach ($tampers as $id => $settings) {
       $tamper = capx_tamper_load_tampers(array('id' => $id));
       $tamper = reset($tamper);
-      $tamper->weight = $weight['weight'];
+      $tamper->weight = $settings['weight'];
       capx_tamper_save_instance($tamper);
+
+      if (!$settings['enabled']) {
+        $disabled[$tamper->id] = TRUE;
+      }
+      else {
+        unset($disabled[$tamper->id]);
+      }
     }
   }
+  variable_set('capx_tamper_disabled', $disabled);
 }
 
 /**
  * Tamper add form.
  *
- * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ * @param CFEntity $mapper
  *   CAPx Mapper used for the tamper.
  * @param string $source
  *   JSON string path.
@@ -139,8 +164,7 @@ function capx_tamper_list_form_submit($form, &$form_state) {
  * @return array
  *   Form render array.
  */
-function capx_tamper_add_form($form, &$form_state, $mapper, $source) {
-  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+function capx_tamper_add_form($form, &$form_state, CFEntity $mapper, $source) {
   drupal_set_title(t('Add Tamper Plugin'));
   capx_tamper_breadcrumb($mapper, TRUE);
   $source = hex2bin($source);
@@ -228,6 +252,11 @@ function capx_tamper_add_form($form, &$form_state, $mapper, $source) {
 
 /**
  * Tamper add form validation.
+ *
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State Array.
  */
 function capx_tamper_add_form_validate($form, &$form_state) {
   if ($form_state['triggering_element']['#value'] == t('Add')) {
@@ -249,10 +278,15 @@ function capx_tamper_add_form_validate($form, &$form_state) {
 
 /**
  * Tamper add form submit to save to table.
+ *
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State Array.
  */
 function capx_tamper_add_form_submit($form, &$form_state) {
   if ($form_state['triggering_element']['#value'] == t('Add')) {
-    /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+    /** @var CFEntity $mapper */
     $mapper = $form_state['mapper'];
     $id = implode('-', array(
       $mapper->identifier(),
@@ -269,7 +303,6 @@ function capx_tamper_add_form_submit($form, &$form_state) {
     $tamper->weight = '0';
     $tamper->description = $form_state['values']['description'];
 
-
     capx_tamper_save_instance($tamper);
     $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
 
@@ -285,7 +318,11 @@ function capx_tamper_add_form_submit($form, &$form_state) {
 /**
  * Tamper plugin edit form.
  *
- * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State Array.
+ * @param CFEntity $mapper
  *   CAPx Mapper used for the tamper.
  * @param string $tamper_id
  *   CAPx Tamper id.
@@ -294,7 +331,6 @@ function capx_tamper_add_form_submit($form, &$form_state) {
  *   Form render array.
  */
 function capx_tamper_edit_form($form, &$form_state, CFEntity $mapper, $tamper_id) {
-  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
   $tamper = reset($tamper);
   if (!$tamper) {
@@ -336,9 +372,14 @@ function capx_tamper_edit_form($form, &$form_state, CFEntity $mapper, $tamper_id
 
 /**
  * Tamper edit validation.
+ *
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State Array.
  */
 function capx_tamper_edit_form_validate($form, &$form_state) {
-  $plugin_id = $form_state['instance']->plugin_id;
+  $plugin_id = $form_state['tamper']->plugin_id;
   $plugin = feeds_tamper_get_plugin($plugin_id);
   if ($plugin['validate']) {
     $plugin['validate']($form_state['values']['settings']);
@@ -347,6 +388,11 @@ function capx_tamper_edit_form_validate($form, &$form_state) {
 
 /**
  * Tamper plugin edit submit.
+ *
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State Array.
  */
 function capx_tamper_edit_form_submit($form, &$form_state) {
   $mapper = $form_state['mapper'];
@@ -364,7 +410,11 @@ function capx_tamper_edit_form_submit($form, &$form_state) {
 /**
  * Confirmation of delete tamper.
  *
- * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State Array.
+ * @param CFEntity $mapper
  *   CAPx Mapper used for the tamper.
  * @param string $tamper_id
  *   CAPx Tamper id.
@@ -402,7 +452,7 @@ function capx_tamper_delete_form($form, &$form_state, CFEntity $mapper, $tamper_
  */
 function capx_tamper_delete_form_submit($form, &$form_state) {
   $tamper = $form_state['tamper'];
-  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+  /** @var CFEntity $mapper */
   $mapper = $form_state['mapper'];
   capx_tamper_delete_instance($tamper);
 
@@ -424,14 +474,24 @@ function capx_tamper_delete_form_submit($form, &$form_state) {
 
 /**
  * Checks for existing machine name.
+ *
+ * @param string $id
+ *   Machine name of the new plugin.
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State Array.
+ *
+ * @return array
+ *   Array of the existing tamper or an empty array.
  */
 function capx_tamper_machine_name_callback($id, $form, &$form_state) {
-  $id = implode('-', array(
+  $check_id = implode('-', array(
     $form_state['mapper']->identifier(),
     $form_state['source'],
     $form_state['values']['id'],
   ));
-  return capx_tamper_load_tampers(array('id' => $id));
+  return capx_tamper_load_tampers(array('id' => $check_id));
 }
 
 /**
@@ -444,12 +504,12 @@ function capx_tamper_ajax_callback($form, $form_state) {
 /**
  * Sets the breadcrumb links for the page.
  *
- * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ * @param CFEntity $mapper
  *   CAPx Mapper in use.
  * @param bool $show_tamper
  *   Show the tamper page in the breadcrumb.
  */
-function capx_tamper_breadcrumb($mapper, $show_tamper = FALSE) {
+function capx_tamper_breadcrumb(CFEntity $mapper, $show_tamper = FALSE) {
   $breadcrumb = array(
     l(t('Home'), '/'),
     l(t('Administration'), '/admin'),

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -52,10 +52,6 @@ function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = 
     '#value' => $mapper->getMachineName(),
   );
 
-  $form['goback'] = array(
-    "#markup" => "<p>" . l(t("Manage Mapping Configuration ->"), "admin/config/capx/mapper/edit/" . $mapper->getMachineName()) . "</p>",
-  );
-
   $sources = capx_tamper_get_mapper_sources($mapper);
 
   foreach ($sources as $path => $targets) {
@@ -151,6 +147,7 @@ function capx_tamper_list_form_submit($form, &$form_state) {
     }
   }
   variable_set('capx_tamper_disabled', $disabled);
+  drupal_set_message(t('Settings saved'));
 }
 
 /**

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -118,13 +118,38 @@ function capx_tamper_list($mapper) {
 }
 
 /**
- * Tamper add form.
+ * Form builder. Calls the correct form for the action.
+ *
+ * @param string $action
+ *   Add, Edit, or Delete.
+ * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ *   CAPx Mapper.
+ * @param string $source
+ *   JSON Path string.
+ *
+ * @return array
+ *   Form render array.
  */
-function capx_tamper_add($form, &$form_state, $mapper_id, $source) {
+function capx_tamper_build_form($action, $mapper, $source) {
+  $form_name = "capx_tamper_{$action}_form";
+  return drupal_get_form($form_name, $mapper, $source);
+}
+
+/**
+ * Tamper add form.
+ *
+ * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ *   CAPx Mapper used for the tamper.
+ * @param string $source
+ *   JSON string path.
+ *
+ * @return array
+ *   Form render array.
+ */
+function capx_tamper_add_form($form, &$form_state, $mapper, $source) {
+  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   drupal_set_title(t('Add Tamper Plugin'));
   $source = hex2bin($source);
-  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
-  $mapper = capx_tamper_mapper_load($mapper_id);
 
   $form_state['mapper'] = $mapper;
   $form_state['source'] = $source;
@@ -208,9 +233,9 @@ function capx_tamper_add($form, &$form_state, $mapper_id, $source) {
 }
 
 /**
- * Tamper add form validation
+ * Tamper add form validation.
  */
-function capx_tamper_add_validate($form, &$form_state) {
+function capx_tamper_add_form_validate($form, &$form_state) {
   if ($form_state['triggering_element']['#value'] == t('Add')) {
     if (capx_tamper_machine_name_callback($form_state['values']['id'], $form, $form_state)) {
       form_set_error('id', t('The machine-readable name is already in use. It must be unique.'));
@@ -231,7 +256,7 @@ function capx_tamper_add_validate($form, &$form_state) {
 /**
  * Tamper add form submit to save to table.
  */
-function capx_tamper_add_submit($form, &$form_state) {
+function capx_tamper_add_form_submit($form, &$form_state) {
   if ($form_state['triggering_element']['#value'] == t('Add')) {
     /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
     $mapper = $form_state['mapper'];
@@ -265,10 +290,17 @@ function capx_tamper_add_submit($form, &$form_state) {
 
 /**
  * Tamper plugin edit form.
+ *
+ * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ *   CAPx Mapper used for the tamper.
+ * @param string $tamper_id
+ *   CAPx Tamper id.
+ *
+ * @return array
+ *   Form render array.
  */
-function capx_tamper_edit($form, &$form_state, $mapper_id, $tamper_id) {
+function capx_tamper_edit_form($form, &$form_state, $mapper, $tamper_id) {
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
-  $mapper = capx_tamper_mapper_load($mapper_id);
   $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
   $tamper = reset($tamper);
   if (!$tamper) {
@@ -312,7 +344,7 @@ function capx_tamper_edit($form, &$form_state, $mapper_id, $tamper_id) {
 /**
  * Tamper edit validation.
  */
-function capx_tamper_edit_validate($form, &$form_state) {
+function capx_tamper_edit_form_validate($form, &$form_state) {
   $plugin_id = $form_state['instance']->plugin_id;
   $plugin = feeds_tamper_get_plugin($plugin_id);
   if ($plugin['validate']) {
@@ -323,7 +355,7 @@ function capx_tamper_edit_validate($form, &$form_state) {
 /**
  * Tamper plugin edit submit.
  */
-function capx_tamper_edit_submit($form, &$form_state) {
+function capx_tamper_edit_form_submit($form, &$form_state) {
   $mapper = $form_state['mapper'];
   $tamper = $form_state['tamper'];
   if (isset($form_state['values']['settings'])) {
@@ -338,9 +370,16 @@ function capx_tamper_edit_submit($form, &$form_state) {
 
 /**
  * Confirmation of delete tamper.
+ *
+ * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ *   CAPx Mapper used for the tamper.
+ * @param string $tamper_id
+ *   CAPx Tamper id.
+ *
+ * @return array
+ *   Form render array.
  */
-function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
-  $mapper = capx_tamper_mapper_load($mapper_id);
+function capx_tamper_delete_form($form, &$form_state, $mapper, $tamper_id) {
   $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
   $tamper = reset($tamper);
   $form_state['tamper'] = $tamper;
@@ -367,7 +406,7 @@ function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
 /**
  * Tamper delete form submit.
  */
-function capx_tamper_delete_submit($form, &$form_state) {
+function capx_tamper_delete_form_submit($form, &$form_state) {
   $tamper = $form_state['tamper'];
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   $mapper = $form_state['mapper'];
@@ -409,8 +448,12 @@ function capx_tamper_ajax_callback($form, $form_state) {
 }
 
 /**
+ * Sets the breadcrumb links for the page.
+ *
  * @param \CAPx\Drupal\Entities\CFEntity $mapper
- * @param null $tamper_id
+ *   CAPx Mapper in use.
+ * @param null|string $tamper_id
+ *   Tamper ID. IF provided, the breadcrumb will go one step further.
  */
 function capx_tamper_breadcrumb($mapper, $tamper_id = NULL) {
   $breadcrumb = array(

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -1,0 +1,319 @@
+<?php
+/**
+ * @file
+ * CAPx Tamper Forms.
+ */
+
+
+function capx_tamper_list($mapper_id) {
+  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+  $mapper = capx_tamper_check_mapper($mapper_id);
+
+  drupal_set_title(t('!mapper Tamper Plugins', array('!mapper' => $mapper->title)));
+  $output = array();
+
+  $output['goback'] = array(
+    "#markup" => "<p>" . l(t("Manage Mapping Configuration ->"), "admin/config/capx/mapper/edit/" . $mapper_id) . "</p>",
+  );
+
+  $header = array(
+    t('Description'),
+    t('Plugin'),
+    t('Operations'),
+    t('Enabled'),
+  );
+  $fields = array();
+  foreach ($mapper->fields as $field_key => $field_settings) {
+    $field_settings = array_filter($field_settings);
+    if ($field_settings) {
+      $fields[$field_key] = $field_settings[key($field_settings)];
+    }
+  }
+
+  $sources = array_merge($mapper->properties, $fields);
+
+  foreach ($sources as $field_key => $path) {
+    $rows = array();
+
+    $instance = field_info_instance($mapper->entity_type, $field_key, $mapper->bundle_type);
+
+    foreach (capx_tamper_get_tampers($mapper_id, $field_key) as $tamper) {
+      $edit_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper['id']}/edit";
+      $delete_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper['id']}/delete";
+      $plugin = feeds_tamper_get_plugin($tamper['plugin_id']);
+      $rows[] = array(
+        $tamper['description'],
+        $plugin['name'],
+        l(t('Edit'), $edit_url) . ' | ' . l(t('Delete'), $delete_url),
+        '&#x2705',
+      );
+    }
+
+    if (!$rows) {
+      $rows[] = array(
+        array(
+          'data' => t('No plugins defined'),
+          'colspan' => count($header),
+        ),
+      );
+    }
+
+    $rows[] = array(
+      array(
+        'data' => l(t('Add Plugin'), CAPX_TAMPER . "/$mapper_id/tamper/add/$field_key"),
+        'colspan' => count($header),
+      ),
+    );
+    $output[$field_key] = array(
+      '#theme' => 'table',
+      '#caption' => t('!from -> !to', array(
+        '!from' => $path,
+        '!to' => $instance ? $instance['label'] : $field_key,
+      )),
+      '#header' => $header,
+      '#rows' => $rows,
+    );
+
+  }
+
+  return $output;
+}
+
+function capx_tamper_add($form, &$form_state, $mapper_id, $source) {
+  drupal_set_title(t('Add Tamper Plugin'));
+  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+  $mapper = capx_tamper_check_mapper($mapper_id);
+
+  $form_state['mapper'] = $mapper;
+  $form_state['source'] = $source;
+  $form['#attached']['css'][] = drupal_get_path('module', 'capx_tamper') . '/css/capx_tamper.css';
+
+  // Build plugin select list.
+  $capx_tamper_plugins = feeds_tamper_get_plugins();
+  $plugins = array();
+  foreach ($capx_tamper_plugins as $plugin_id => $plugin) {
+    $plugins[t($plugin['category'])][$plugin_id] = t($plugin['name']);
+  }
+  ksort($plugins);
+  foreach ($plugins as &$p) {
+    asort($p);
+  }
+
+  $machine_name = key(reset($plugins));
+  if (!empty($form_state['values']['plugin_id'])) {
+    $machine_name = $form_state['values']['plugin_id'];
+  }
+  $plugin = feeds_tamper_get_plugin($machine_name);
+
+  $form['plugin_id'] = array(
+    '#title' => t('The plugin to add'),
+    '#type' => 'select',
+    '#options' => $plugins,
+    '#default_value' => '',
+    '#tree' => TRUE,
+    '#ajax' => array(
+      'callback' => 'capx_tamper_ajax_callback',
+      'wrapper' => 'capx-tamper-plugin',
+      'progress' => 'none',
+    ),
+  );
+  $form['update'] = array(
+    '#type' => 'submit',
+    '#limit_validation_errors' => array(array('plugin_id')),
+    '#submit' => array('capx_tamper_ui_add_plugin_form_submit'),
+    '#value' => t('Choose'),
+    '#attributes' => array('class' => array('no-js')),
+  );
+  $form['plugin']['#prefix'] = '<div class="clear-fix" id="capx-tamper-plugin">';
+  $form['plugin']['#suffix'] = '</div>';
+
+  $form['plugin']['description'] = array(
+    '#title' => t('Description'),
+    '#type' => 'textfield',
+    '#default_value' => $plugin['default description'] ? t($plugin['default description']) : t($plugin['name']),
+    '#required' => TRUE,
+    '#description' => t('A useful description of what this plugin is doing.'),
+  );
+  $form['plugin']['id'] = array(
+    '#title' => t('Machine name'),
+    '#type' => 'machine_name',
+    '#maxlength' => 32,
+    '#machine_name' => array(
+      'exists' => 'capx_tamper_machine_name_callback',
+      'source' => array('plugin', 'description'),
+    ),
+    '#default_value' => $machine_name,
+  );
+  $form['plugin']['settings'] = array(
+    '#title' => t('Configure @name', array('@name' => $plugin['name'])),
+    '#type' => 'fieldset',
+    '#tree' => TRUE,
+  );
+  $importer = new stdClass();
+
+  $form['plugin']['settings'] += $plugin['form']($importer, $source, array(), $form_state);
+  $form['add'] = array(
+    '#type' => 'submit',
+    '#value' => t('Add'),
+  );
+
+  return $form;
+}
+
+function capx_tamper_add_validate($form, &$form_state) {
+  if ($form_state['triggering_element']['#value'] == t('Add')) {
+    if (capx_tamper_machine_name_callback($form_state['values']['id'], $form, $form_state)) {
+      form_set_error('id', t('The machine-readable name is already in use. It must be unique.'));
+      return;
+    }
+    $plugin_id = $form_state['values']['plugin_id'];
+    $plugin = feeds_tamper_get_plugin($plugin_id);
+    if ($plugin['validate'] && isset($form_state['values']['settings'])) {
+      $plugin['validate']($form_state['values']['settings']);
+    }
+    return;
+  }
+  unset($form_state['input']['id']);
+  unset($form_state['input']['description']);
+  unset($form_state['input']['settings']);
+}
+
+function capx_tamper_add_submit($form, &$form_state) {
+  if ($form_state['triggering_element']['#value'] == t('Add')) {
+    /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+    $mapper = $form_state['mapper'];
+    $id = implode('-', array(
+      $mapper->identifier(),
+      $form_state['source'],
+      $form_state['values']['id'],
+    ));
+    $tamper = array(
+      'id' => $id,
+      'mapper' => $mapper->identifier(),
+      'source' => $form_state['source'],
+      'plugin_id' => $form_state['values']['plugin_id'],
+      'settings' => $form_state['values']['settings'],
+      'weight' => '0',
+      'description' => $form_state['values']['description'],
+    );
+
+    capx_tamper_save_instance($tamper);
+    $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
+
+    drupal_set_message(t('Plugin %description was successfully added to %source.', array(
+      '%description' => $form_state['values']['description'],
+      '%source' => $form_state['source'],
+    )));
+    return;
+  }
+  $form_state['rebuild'] = TRUE;
+}
+
+
+function capx_tamper_machine_name_callback($id, $form, &$form_state) {
+  $id = implode('-', array(
+    $form_state['mapper']->identifier(),
+    $form_state['source'],
+    $form_state['values']['id'],
+  ));
+  return capx_tamper_load_tamper($id);
+}
+
+
+/**
+ * Ajax callback for add plugin form.
+ */
+function capx_tamper_ajax_callback($form, $form_state) {
+  return $form['plugin'];
+}
+
+function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
+  $mapper = capx_tamper_check_mapper($mapper_id);
+
+  $tamper = capx_tamper_load_tamper($tamper_id);
+  $form_state['tamper'] = $tamper;
+  $form_state['mapper'] = $mapper;
+  $question = t('Would you really like to delete the plugin @instance?', array('@instance' => $instance->description));
+  $button_label = t('Delete');
+
+  return confirm_form(
+    $form,
+    $question,
+    CAPX_TAMPER . "/{$mapper->identifier()}/tamper",
+    NULL,
+    $button_label
+  );
+}
+
+function capx_tamper_delete_submit($form, &$form_state) {
+  $tamper = $form_state['tamper'];
+  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+  $mapper = $form_state['mapper'];
+
+  capx_tamper_delete_instance($tamper);
+
+  drupal_set_message(t('The plugin %plugin has been deleted from %source.', array(
+    '%plugin' => $tamper['description'],
+    '%source' => $tamper['source'],
+  )));
+
+  $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
+}
+
+function capx_tamper_check_mapper($mapper_id) {
+  $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
+  if (!$mapper) {
+    drupal_not_found();
+    drupal_exit();
+  }
+  return $mapper;
+}
+
+function capx_tamper_edit($form, &$form_state, $mapper_id, $tamper_id) {
+  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+  $mapper = capx_tamper_check_mapper($mapper_id);
+  $form_state['mapper'] = $mapper;
+  $tamper = capx_tamper_load_tamper($tamper_id);
+  $form_state['tamper'] = $tamper;
+
+  drupal_set_title(t('Edit !title', array('!title' => $tamper['description'])));
+
+  $plugin = feeds_tamper_get_plugin($tamper['plugin_id']);
+  $form['#tree'] = TRUE;
+
+  $form['description'] = array(
+    '#title' => t('Description'),
+    '#type' => 'textfield',
+    '#description' => t('A useful description of what this plugin is doing.'),
+    '#default_value' => $tamper['description'],
+  );
+  $form['settings'] = array(
+    '#title' => t('Configure @plugin', array('@plugin' => $plugin['name'])),
+    '#type' => 'fieldset',
+    '#tree' => TRUE,
+  );
+  $importer = new stdClass();
+  $form['settings'] += $plugin['form']($importer, $tamper['source'], $tamper['settings'], $form_state);
+
+  $form['save'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+  );
+
+  $form['#attached']['css'][] = drupal_get_path('module', 'capx_tamper') . '/css/capx_tamper.css';
+
+  return $form;
+}
+
+function capx_tamper_edit_submit($form, &$form_state) {
+  $mapper = $form_state['mapper'];
+  $tamper = $form_state['tamper'];
+  if (isset($form_state['values']['settings'])) {
+    $tamper['settings'] = $form_state['values']['settings'];
+  }
+  $tamper['description'] = $form_state['values']['description'];
+
+  capx_tamper_save_instance($tamper);
+  drupal_set_message(t('The plugin %plugin has been updated.', array('%plugin' => $tamper['description'])));
+  $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
+}

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -29,6 +29,7 @@ function capx_tamper_list($mapper_id) {
   $header = array(
     t('Description'),
     t('Plugin'),
+    t('Status'),
     t('Operations'),
     t('Enabled'),
   );
@@ -51,10 +52,34 @@ function capx_tamper_list($mapper_id) {
       $edit_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/edit";
       $delete_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/delete";
       $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
+
+      $status = '';
+      $edit = '';
+      $delete = '';
+      if ($tamper->export_type == EXPORT_IN_CODE) {
+        $status = t('Default');
+        $edit = l(t('Override'), $edit_url);
+        $delete = '';
+      }
+      elseif ($tamper->export_type == EXPORT_IN_DATABASE) {
+        $status = t('Normal');
+        $edit = l(t('Edit'), $edit_url);
+        $delete = l(t('Delete'), $delete_url);
+      }
+      elseif ($tamper->export_type == (EXPORT_IN_CODE | EXPORT_IN_DATABASE)) {
+        $status = t('Overridden');
+        $edit = l(t('Edit'), $edit_url);
+        $delete = l(t('Revert'), $delete_url);
+      }
+
+      if($delete){
+        $edit .= " | $delete";
+      }
       $rows[] = array(
         $tamper->description,
         $plugin['name'],
-        l(t('Edit'), $edit_url) . ' | ' . l(t('Delete'), $delete_url),
+        $status,
+        $edit,
         '&#x2705',
       );
     }
@@ -258,8 +283,16 @@ function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
   $tamper = reset(capx_tamper_load_tampers(array('id' => $tamper_id)));
   $form_state['tamper'] = $tamper;
   $form_state['mapper'] = $mapper;
-  $question = t('Would you really like to delete the plugin @instance?', array('@instance' => $tamper->description));
-  $button_label = t('Delete');
+
+  if ($tamper->export_type & EXPORT_IN_CODE) {
+    $question = t('Would you really like to revert the plugin @tamper?', array('@tamper' => $tamper->description));
+    $button_label = t('Revert');
+  }
+  else {
+    $question = t('Would you really like to delete the plugin @tamper?', array('@tamper' => $tamper->description));
+    $button_label = t('Delete');
+  }
+
 
   return confirm_form(
     $form,
@@ -277,13 +310,20 @@ function capx_tamper_delete_submit($form, &$form_state) {
   $tamper = $form_state['tamper'];
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   $mapper = $form_state['mapper'];
-
   capx_tamper_delete_instance($tamper);
 
-  drupal_set_message(t('The plugin %plugin has been deleted from %source.', array(
-    '%plugin' => $tamper->description,
-    '%source' => $tamper->source,
-  )));
+  switch ($tamper->export_type) {
+    case EXPORT_IN_DATABASE:
+      drupal_set_message(t('The plugin %plugin has been deleted from %source.', array(
+        '%plugin' => $tamper->description,
+        '%source' => $tamper->source,
+      )));
+      break;
+
+    case EXPORT_IN_CODE | EXPORT_IN_DATABASE:
+      drupal_set_message(t('The plugin %plugin has been reverted.', array('%plugin' => $tamper->description)));
+      break;
+  }
 
   $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
 }

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -65,28 +65,9 @@ function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = 
     foreach ($path_tampers as $tamper) {
       $edit_url = CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/{$tamper->id}/edit";
       $delete_url = CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/{$tamper->id}/delete";
-      $status = '';
-      $edit = '';
-      $delete = '';
-      if ($tamper->export_type == EXPORT_IN_CODE) {
-        $status = t('Default');
-        $edit = l(t('Override'), $edit_url);
-        $delete = '';
-      }
-      elseif ($tamper->export_type == EXPORT_IN_DATABASE) {
-        $status = t('Normal');
-        $edit = l(t('Edit'), $edit_url);
-        $delete = l(t('Delete'), $delete_url);
-      }
-      elseif ($tamper->export_type == (EXPORT_IN_CODE | EXPORT_IN_DATABASE)) {
-        $status = t('Overridden');
-        $edit = l(t('Edit'), $edit_url);
-        $delete = l(t('Revert'), $delete_url);
-      }
 
-      if (!empty($delete)) {
-        $edit .= " | $delete";
-      }
+      $edit = l(t('Edit'), $edit_url);
+      $edit .= " | " . l(t('Delete'), $delete_url);
 
       $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
       $form['tampers'][$path][$tamper->id]['description'] = array(
@@ -94,9 +75,6 @@ function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = 
       );
       $form['tampers'][$path][$tamper->id]['plugin_id'] = array(
         '#markup' => t($plugin['name']),
-      );
-      $form['tampers'][$path][$tamper->id]['status'] = array(
-        '#markup' => $status,
       );
       $form['tampers'][$path][$tamper->id]['operations'] = array(
         '#markup' => $edit,
@@ -300,14 +278,14 @@ function capx_tamper_add_form_submit($form, &$form_state) {
     $tamper->weight = '0';
     $tamper->description = $form_state['values']['description'];
 
-    capx_tamper_save_instance($tamper);
-    $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
-
-    drupal_set_message(t('Plugin %description was successfully added to %source.', array(
-      '%description' => $form_state['values']['description'],
-      '%source' => $form_state['source'],
-    )));
-    return;
+    if (capx_tamper_save_instance($tamper)) {
+      $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
+      drupal_set_message(t('Plugin %description was successfully added to %source.', array(
+        '%description' => $form_state['values']['description'],
+        '%source' => $form_state['source'],
+      )));
+      return;
+    }
   }
   $form_state['rebuild'] = TRUE;
 }
@@ -399,9 +377,10 @@ function capx_tamper_edit_form_submit($form, &$form_state) {
   }
   $tamper->description = $form_state['values']['description'];
 
-  capx_tamper_save_instance($tamper);
-  drupal_set_message(t('The plugin %plugin has been updated.', array('%plugin' => $tamper->description)));
-  $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
+  if (capx_tamper_save_instance($tamper)) {
+    drupal_set_message(t('The plugin %plugin has been updated.', array('%plugin' => $tamper->description)));
+    $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
+  }
 }
 
 /**

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -6,6 +6,26 @@
  * Mostly taken from feeds_tamper_ui.admin.inc.
  */
 
+use \CAPx\Drupal\Entities\CFEntity;
+
+/**
+ * Form builder. Calls the correct form for the action.
+ *
+ * @param string $action
+ *   Add, Edit, or Delete.
+ * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ *   CAPx Mapper.
+ * @param string|null $source
+ *   JSON Path string.
+ *
+ * @return array
+ *   Form render array.
+ */
+function capx_tamper_build_form($action, $mapper, $source = NULL) {
+  $form_name = "capx_tamper_{$action}_form";
+  return drupal_get_form($form_name, $mapper, $source);
+}
+
 /**
  * Shows the current tampers in table format for the given CAPx Mapper.
  *
@@ -15,47 +35,33 @@
  * @return array
  *   Renderable array.
  */
-function capx_tamper_list($mapper) {
+function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = NULL) {
   drupal_set_title(t('!mapper Tamper Plugins', array('!mapper' => $mapper->title)));
   capx_tamper_breadcrumb($mapper);
-  $output = array();
 
-  $output['goback'] = array(
+  $form['#tree'] = TRUE;
+  $form['mapper'] = array(
+    '#type' => 'hidden',
+    '#value' => $mapper->getMachineName(),
+  );
+
+  $form['goback'] = array(
     "#markup" => "<p>" . l(t("Manage Mapping Configuration ->"), "admin/config/capx/mapper/edit/" . $mapper->getMachineName()) . "</p>",
   );
 
-  $header = array(
-    t('Description'),
-    t('Plugin'),
-    t('Status'),
-    t('Operations'),
-    t('Enabled'),
-  );
   $sources = capx_tamper_get_mapper_sources($mapper);
 
-  foreach ($sources as $path => $field_keys) {
-    $rows = array();
-
-    $destination = array();
-    foreach ($field_keys as $field_key) {
-      if ($instance = field_info_instance($mapper->entity_type, $field_key, $mapper->bundle_type)) {
-        $destination[] = $instance['label'];
-      }
-      else {
-        $destination[] = $field_key;
-      }
-    }
-    $conditions = array(
+  foreach ($sources as $path => $targets) {
+    $path_tampers = capx_tamper_load_tampers(array(
       'mapper' => $mapper->getMachineName(),
       'source' => $path,
-    );
+    ));
 
+    $form['tampers'][$path] = array();
 
-    foreach (capx_tamper_load_tampers($conditions) as $tamper) {
-      $edit_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/edit";
-      $delete_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/delete";
-      $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
-
+    foreach ($path_tampers as $tamper) {
+      $edit_url = CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/{$tamper->id}/edit";
+      $delete_url = CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/{$tamper->id}/delete";
       $status = '';
       $edit = '';
       $delete = '';
@@ -75,64 +81,51 @@ function capx_tamper_list($mapper) {
         $delete = l(t('Revert'), $delete_url);
       }
 
-      if ($delete) {
+      if (!empty($delete)) {
         $edit .= " | $delete";
       }
-      $rows[] = array(
-        $tamper->description,
-        $plugin['name'],
-        $status,
-        $edit,
-        '&#x2705',
-      );
-    }
 
-    if (!$rows) {
-      $rows[] = array(
-        array(
-          'data' => t('No plugins defined'),
-          'colspan' => count($header),
+      $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
+      $form['tampers'][$path][$tamper->id]['description'] = array(
+        '#markup' => t($tamper->description),
+      );
+      $form['tampers'][$path][$tamper->id]['plugin_id'] = array(
+        '#markup' => t($plugin['name']),
+      );
+      $form['tampers'][$path][$tamper->id]['status'] = array(
+        '#markup' => $status,
+      );
+      $form['tampers'][$path][$tamper->id]['operations'] = array(
+        '#markup' => $edit,
+      );
+      $form['tampers'][$path][$tamper->id]['weight'] = array(
+        '#type' => 'weight',
+        '#title' => t('Weight'),
+        '#default_value' => $tamper->weight,
+        '#attributes' => array(
+          'class' => array(capx_tamper_table_id($path) . '-weight'),
         ),
       );
     }
-
-    $rows[] = array(
-      array(
-        'data' => l(t('Add Plugin'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/add/" . bin2hex($path)),
-        'colspan' => count($header),
-      ),
-    );
-    $output[$path] = array(
-      '#theme' => 'table',
-      '#caption' => t('!from -> !to', array(
-        '!from' => $path,
-        '!to' => implode(', ', $destination),
-      )),
-      '#header' => $header,
-      '#rows' => $rows,
-    );
-
   }
 
-  return $output;
+  $form['save'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+  );
+
+  return $form;
 }
 
-/**
- * Form builder. Calls the correct form for the action.
- *
- * @param string $action
- *   Add, Edit, or Delete.
- * @param \CAPx\Drupal\Entities\CFEntity $mapper
- *   CAPx Mapper.
- * @param string $source
- *   JSON Path string.
- *
- * @return array
- *   Form render array.
- */
-function capx_tamper_build_form($action, $mapper, $source) {
-  $form_name = "capx_tamper_{$action}_form";
-  return drupal_get_form($form_name, $mapper, $source);
+function capx_tamper_list_form_submit($form, &$form_state) {
+  foreach ($form_state['values']['tampers'] as $path => $tampers) {
+    foreach ($tampers as $id => $weight) {
+      $tamper = capx_tamper_load_tampers(array('id' => $id));
+      $tamper = reset($tamper);
+      $tamper->weight = $weight['weight'];
+      capx_tamper_save_instance($tamper);
+    }
+  }
 }
 
 /**
@@ -149,6 +142,7 @@ function capx_tamper_build_form($action, $mapper, $source) {
 function capx_tamper_add_form($form, &$form_state, $mapper, $source) {
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   drupal_set_title(t('Add Tamper Plugin'));
+  capx_tamper_breadcrumb($mapper, TRUE);
   $source = hex2bin($source);
 
   $form_state['mapper'] = $mapper;
@@ -299,7 +293,7 @@ function capx_tamper_add_form_submit($form, &$form_state) {
  * @return array
  *   Form render array.
  */
-function capx_tamper_edit_form($form, &$form_state, $mapper, $tamper_id) {
+function capx_tamper_edit_form($form, &$form_state, CFEntity $mapper, $tamper_id) {
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
   $tamper = reset($tamper);
@@ -307,8 +301,8 @@ function capx_tamper_edit_form($form, &$form_state, $mapper, $tamper_id) {
     drupal_not_found();
     drupal_exit();
   }
+  capx_tamper_breadcrumb($mapper, TRUE);
 
-  capx_tamper_breadcrumb($mapper, $tamper_id);
   $form_state['mapper'] = $mapper;
   $form_state['tamper'] = $tamper;
 
@@ -337,7 +331,6 @@ function capx_tamper_edit_form($form, &$form_state, $mapper, $tamper_id) {
   );
 
   $form['#attached']['css'][] = drupal_get_path('module', 'capx_tamper') . '/css/capx_tamper.css';
-
   return $form;
 }
 
@@ -379,7 +372,8 @@ function capx_tamper_edit_form_submit($form, &$form_state) {
  * @return array
  *   Form render array.
  */
-function capx_tamper_delete_form($form, &$form_state, $mapper, $tamper_id) {
+function capx_tamper_delete_form($form, &$form_state, CFEntity $mapper, $tamper_id) {
+  capx_tamper_breadcrumb($mapper, TRUE);
   $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
   $tamper = reset($tamper);
   $form_state['tamper'] = $tamper;
@@ -452,10 +446,10 @@ function capx_tamper_ajax_callback($form, $form_state) {
  *
  * @param \CAPx\Drupal\Entities\CFEntity $mapper
  *   CAPx Mapper in use.
- * @param null|string $tamper_id
- *   Tamper ID. IF provided, the breadcrumb will go one step further.
+ * @param bool $show_tamper
+ *   Show the tamper page in the breadcrumb.
  */
-function capx_tamper_breadcrumb($mapper, $tamper_id = NULL) {
+function capx_tamper_breadcrumb($mapper, $show_tamper = FALSE) {
   $breadcrumb = array(
     l(t('Home'), '/'),
     l(t('Administration'), '/admin'),
@@ -463,9 +457,9 @@ function capx_tamper_breadcrumb($mapper, $tamper_id = NULL) {
     l(t('CAPx'), '/admin/config/capx'),
     l(t('Map'), '/admin/config/capx/mapper'),
     l(t($mapper->title), CAPX_TAMPER . "/edit/{$mapper->getMachineName()}"),
-
   );
-  if ($tamper_id) {
+
+  if ($show_tamper) {
     $breadcrumb[] = l(t('Tamper'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper");
   }
   drupal_set_breadcrumb($breadcrumb);

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -15,15 +15,14 @@
  * @return array
  *   Renderable array.
  */
-function capx_tamper_list($mapper_id) {
+function capx_tamper_list($mapper) {
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
-  $mapper = capx_tamper_check_mapper($mapper_id);
-
   drupal_set_title(t('!mapper Tamper Plugins', array('!mapper' => $mapper->title)));
+  capx_tamper_breadcrumb($mapper);
   $output = array();
 
   $output['goback'] = array(
-    "#markup" => "<p>" . l(t("Manage Mapping Configuration ->"), "admin/config/capx/mapper/edit/" . $mapper_id) . "</p>",
+    "#markup" => "<p>" . l(t("Manage Mapping Configuration ->"), "admin/config/capx/mapper/edit/" . $mapper->getMachineName()) . "</p>",
   );
 
   $header = array(
@@ -33,24 +32,30 @@ function capx_tamper_list($mapper_id) {
     t('Operations'),
     t('Enabled'),
   );
-  $fields = array();
-  foreach ($mapper->fields as $field_key => $field_settings) {
-    $field_settings = array_filter($field_settings);
-    if ($field_settings) {
-      $fields[$field_key] = $field_settings[key($field_settings)];
-    }
-  }
+  $sources = capx_tamper_get_mapper_sources($mapper);
 
-  $sources = array_merge($mapper->properties, $fields);
-
-  foreach ($sources as $field_key => $path) {
+  foreach ($sources as $path => $field_keys) {
     $rows = array();
 
-    $instance = field_info_instance($mapper->entity_type, $field_key, $mapper->bundle_type);
-    $conditions = array('mapper' => $mapper_id, 'source' => $field_key);
+    $destination = array();
+    foreach ($field_keys as $field_key) {
+      if ($instance = field_info_instance($mapper->entity_type, $field_key, $mapper->bundle_type)) {
+        $destination[] = $instance['label'];
+      }
+      else {
+        $destination[] = $field_key;
+      }
+    }
+    $conditions = array(
+      'mapper' => $mapper->getMachineName(),
+      'source' => $path,
+    );
+
+
     foreach (capx_tamper_load_tampers($conditions) as $tamper) {
-      $edit_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/edit";
-      $delete_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/delete";
+      $hex = bin2hex($tamper->id);
+      $edit_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/$hex/edit";
+      $delete_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/$hex/delete";
       $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
 
       $status = '';
@@ -72,7 +77,7 @@ function capx_tamper_list($mapper_id) {
         $delete = l(t('Revert'), $delete_url);
       }
 
-      if($delete){
+      if ($delete) {
         $edit .= " | $delete";
       }
       $rows[] = array(
@@ -95,15 +100,15 @@ function capx_tamper_list($mapper_id) {
 
     $rows[] = array(
       array(
-        'data' => l(t('Add Plugin'), CAPX_TAMPER . "/$mapper_id/tamper/add/$field_key"),
+        'data' => l(t('Add Plugin'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/add/" . bin2hex($path)),
         'colspan' => count($header),
       ),
     );
-    $output[$field_key] = array(
+    $output[$path] = array(
       '#theme' => 'table',
       '#caption' => t('!from -> !to', array(
         '!from' => $path,
-        '!to' => $instance ? $instance['label'] : $field_key,
+        '!to' => implode(', ', $destination),
       )),
       '#header' => $header,
       '#rows' => $rows,
@@ -115,15 +120,37 @@ function capx_tamper_list($mapper_id) {
 }
 
 /**
+ * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ * @param null $tamper_id
+ */
+function capx_tamper_breadcrumb($mapper, $tamper_id = NULL) {
+  $breadcrumb = array(
+    l(t('Home'), '/'),
+    l(t('Administration'), '/admin'),
+    l(t('Configuration'), '/admin/config'),
+    l(t('CAPx'), '/admin/config/capx'),
+    l(t('Map'), '/admin/config/capx/mapper'),
+    l(t($mapper->title), CAPX_TAMPER . "/edit/{$mapper->getMachineName()}"),
+
+  );
+  if ($tamper_id) {
+    $breadcrumb[] = l(t('Tamper'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper");
+  }
+  drupal_set_breadcrumb($breadcrumb);
+}
+
+/**
  * Tamper add form.
  */
 function capx_tamper_add($form, &$form_state, $mapper_id, $source) {
   drupal_set_title(t('Add Tamper Plugin'));
+  $source = hex2bin($source);
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
-  $mapper = capx_tamper_check_mapper($mapper_id);
+  $mapper = capx_tamper_mapper_load($mapper_id);
 
   $form_state['mapper'] = $mapper;
   $form_state['source'] = $source;
+
   $form['#attached']['css'][] = drupal_get_path('module', 'capx_tamper') . '/css/capx_tamper.css';
 
   // Build plugin select list.
@@ -187,7 +214,7 @@ function capx_tamper_add($form, &$form_state, $mapper_id, $source) {
     '#type' => 'fieldset',
     '#tree' => TRUE,
   );
-  $importer = new stdClass();
+  $importer = new CapxTamper($mapper);
 
   $form['plugin']['settings'] += $plugin['form']($importer, $source, array(), $form_state);
   $form['add'] = array(
@@ -278,9 +305,10 @@ function capx_tamper_ajax_callback($form, $form_state) {
  * Confirmation of delete tamper.
  */
 function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
-  $mapper = capx_tamper_check_mapper($mapper_id);
-
-  $tamper = reset(capx_tamper_load_tampers(array('id' => $tamper_id)));
+  $tamper_id = hex2bin($tamper_id);
+  $mapper = capx_tamper_mapper_load($mapper_id);
+  $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
+  $tamper = reset($tamper);
   $form_state['tamper'] = $tamper;
   $form_state['mapper'] = $mapper;
 
@@ -292,7 +320,6 @@ function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
     $question = t('Would you really like to delete the plugin @tamper?', array('@tamper' => $tamper->description));
     $button_label = t('Delete');
   }
-
 
   return confirm_form(
     $form,
@@ -329,25 +356,21 @@ function capx_tamper_delete_submit($form, &$form_state) {
 }
 
 /**
- * Checks for valid capx mapper and throws 404 if invalid.
- */
-function capx_tamper_check_mapper($mapper_id) {
-  $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
-  if (!$mapper) {
-    drupal_not_found();
-    drupal_exit();
-  }
-  return $mapper;
-}
-
-/**
  * Tamper plugin edit form.
  */
 function capx_tamper_edit($form, &$form_state, $mapper_id, $tamper_id) {
+  $tamper_id = hex2bin($tamper_id);
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
-  $mapper = capx_tamper_check_mapper($mapper_id);
+  $mapper = capx_tamper_mapper_load($mapper_id);
+  $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
+  $tamper = reset($tamper);
+  if (!$tamper) {
+    drupal_not_found();
+    drupal_exit();
+  }
+
+  capx_tamper_breadcrumb($mapper, $tamper_id);
   $form_state['mapper'] = $mapper;
-  $tamper = reset(capx_tamper_load_tampers(array('id' => $tamper_id)));
   $form_state['tamper'] = $tamper;
 
   drupal_set_title(t('Edit !title', array('!title' => $tamper->description)));
@@ -366,7 +389,7 @@ function capx_tamper_edit($form, &$form_state, $mapper_id, $tamper_id) {
     '#type' => 'fieldset',
     '#tree' => TRUE,
   );
-  $importer = new stdClass();
+  $importer = new CapxTamper($mapper);
   $form['settings'] += $plugin['form']($importer, $tamper->source, $tamper->settings, $form_state);
 
   $form['save'] = array(

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -9,14 +9,13 @@
 /**
  * Shows the current tampers in table format for the given CAPx Mapper.
  *
- * @param string $mapper_id
- *   Machine name of the mapper to apply tamper to.
+ * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ *   Mapper to apply tamper to.
  *
  * @return array
  *   Renderable array.
  */
 function capx_tamper_list($mapper) {
-  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   drupal_set_title(t('!mapper Tamper Plugins', array('!mapper' => $mapper->title)));
   capx_tamper_breadcrumb($mapper);
   $output = array();
@@ -53,9 +52,8 @@ function capx_tamper_list($mapper) {
 
 
     foreach (capx_tamper_load_tampers($conditions) as $tamper) {
-      $hex = bin2hex($tamper->id);
-      $edit_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/$hex/edit";
-      $delete_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/$hex/delete";
+      $edit_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/edit";
+      $delete_url = CAPX_TAMPER . "/{$mapper->identifier()}/tamper/{$tamper->id}/delete";
       $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
 
       $status = '';
@@ -120,26 +118,6 @@ function capx_tamper_list($mapper) {
 }
 
 /**
- * @param \CAPx\Drupal\Entities\CFEntity $mapper
- * @param null $tamper_id
- */
-function capx_tamper_breadcrumb($mapper, $tamper_id = NULL) {
-  $breadcrumb = array(
-    l(t('Home'), '/'),
-    l(t('Administration'), '/admin'),
-    l(t('Configuration'), '/admin/config'),
-    l(t('CAPx'), '/admin/config/capx'),
-    l(t('Map'), '/admin/config/capx/mapper'),
-    l(t($mapper->title), CAPX_TAMPER . "/edit/{$mapper->getMachineName()}"),
-
-  );
-  if ($tamper_id) {
-    $breadcrumb[] = l(t('Tamper'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper");
-  }
-  drupal_set_breadcrumb($breadcrumb);
-}
-
-/**
  * Tamper add form.
  */
 function capx_tamper_add($form, &$form_state, $mapper_id, $source) {
@@ -163,6 +141,10 @@ function capx_tamper_add($form, &$form_state, $mapper_id, $source) {
   foreach ($plugins as &$p) {
     asort($p);
   }
+
+  // Unsupported tampers.
+  unset($plugins[t('Filter')]);
+  unset($plugins[t('Field Collection')]);
 
   $machine_name = key(reset($plugins));
   if (!empty($form_state['values']['plugin_id'])) {
@@ -282,84 +264,9 @@ function capx_tamper_add_submit($form, &$form_state) {
 }
 
 /**
- * Checks for existing machine name.
- */
-function capx_tamper_machine_name_callback($id, $form, &$form_state) {
-  $id = implode('-', array(
-    $form_state['mapper']->identifier(),
-    $form_state['source'],
-    $form_state['values']['id'],
-  ));
-  return capx_tamper_load_tampers(array('id' => $id));
-}
-
-
-/**
- * Ajax callback for add plugin form.
- */
-function capx_tamper_ajax_callback($form, $form_state) {
-  return $form['plugin'];
-}
-
-/**
- * Confirmation of delete tamper.
- */
-function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
-  $tamper_id = hex2bin($tamper_id);
-  $mapper = capx_tamper_mapper_load($mapper_id);
-  $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
-  $tamper = reset($tamper);
-  $form_state['tamper'] = $tamper;
-  $form_state['mapper'] = $mapper;
-
-  if ($tamper->export_type & EXPORT_IN_CODE) {
-    $question = t('Would you really like to revert the plugin @tamper?', array('@tamper' => $tamper->description));
-    $button_label = t('Revert');
-  }
-  else {
-    $question = t('Would you really like to delete the plugin @tamper?', array('@tamper' => $tamper->description));
-    $button_label = t('Delete');
-  }
-
-  return confirm_form(
-    $form,
-    $question,
-    CAPX_TAMPER . "/{$mapper->identifier()}/tamper",
-    NULL,
-    $button_label
-  );
-}
-
-/**
- * Tamper delete form submit.
- */
-function capx_tamper_delete_submit($form, &$form_state) {
-  $tamper = $form_state['tamper'];
-  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
-  $mapper = $form_state['mapper'];
-  capx_tamper_delete_instance($tamper);
-
-  switch ($tamper->export_type) {
-    case EXPORT_IN_DATABASE:
-      drupal_set_message(t('The plugin %plugin has been deleted from %source.', array(
-        '%plugin' => $tamper->description,
-        '%source' => $tamper->source,
-      )));
-      break;
-
-    case EXPORT_IN_CODE | EXPORT_IN_DATABASE:
-      drupal_set_message(t('The plugin %plugin has been reverted.', array('%plugin' => $tamper->description)));
-      break;
-  }
-
-  $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
-}
-
-/**
  * Tamper plugin edit form.
  */
 function capx_tamper_edit($form, &$form_state, $mapper_id, $tamper_id) {
-  $tamper_id = hex2bin($tamper_id);
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   $mapper = capx_tamper_mapper_load($mapper_id);
   $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
@@ -427,4 +334,96 @@ function capx_tamper_edit_submit($form, &$form_state) {
   capx_tamper_save_instance($tamper);
   drupal_set_message(t('The plugin %plugin has been updated.', array('%plugin' => $tamper->description)));
   $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
+}
+
+/**
+ * Confirmation of delete tamper.
+ */
+function capx_tamper_delete($form, &$form_state, $mapper_id, $tamper_id) {
+  $mapper = capx_tamper_mapper_load($mapper_id);
+  $tamper = capx_tamper_load_tampers(array('id' => $tamper_id));
+  $tamper = reset($tamper);
+  $form_state['tamper'] = $tamper;
+  $form_state['mapper'] = $mapper;
+
+  if ($tamper->export_type & EXPORT_IN_CODE) {
+    $question = t('Would you really like to revert the plugin @tamper?', array('@tamper' => $tamper->description));
+    $button_label = t('Revert');
+  }
+  else {
+    $question = t('Would you really like to delete the plugin @tamper?', array('@tamper' => $tamper->description));
+    $button_label = t('Delete');
+  }
+
+  return confirm_form(
+    $form,
+    $question,
+    CAPX_TAMPER . "/{$mapper->identifier()}/tamper",
+    NULL,
+    $button_label
+  );
+}
+
+/**
+ * Tamper delete form submit.
+ */
+function capx_tamper_delete_submit($form, &$form_state) {
+  $tamper = $form_state['tamper'];
+  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+  $mapper = $form_state['mapper'];
+  capx_tamper_delete_instance($tamper);
+
+  switch ($tamper->export_type) {
+    case EXPORT_IN_DATABASE:
+      drupal_set_message(t('The plugin %plugin has been deleted from %source.', array(
+        '%plugin' => $tamper->description,
+        '%source' => $tamper->source,
+      )));
+      break;
+
+    case EXPORT_IN_CODE | EXPORT_IN_DATABASE:
+      drupal_set_message(t('The plugin %plugin has been reverted.', array('%plugin' => $tamper->description)));
+      break;
+  }
+
+  $form_state['redirect'] = CAPX_TAMPER . "/{$mapper->identifier()}/tamper";
+}
+
+/**
+ * Checks for existing machine name.
+ */
+function capx_tamper_machine_name_callback($id, $form, &$form_state) {
+  $id = implode('-', array(
+    $form_state['mapper']->identifier(),
+    $form_state['source'],
+    $form_state['values']['id'],
+  ));
+  return capx_tamper_load_tampers(array('id' => $id));
+}
+
+/**
+ * Ajax callback for add plugin form.
+ */
+function capx_tamper_ajax_callback($form, $form_state) {
+  return $form['plugin'];
+}
+
+/**
+ * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ * @param null $tamper_id
+ */
+function capx_tamper_breadcrumb($mapper, $tamper_id = NULL) {
+  $breadcrumb = array(
+    l(t('Home'), '/'),
+    l(t('Administration'), '/admin'),
+    l(t('Configuration'), '/admin/config'),
+    l(t('CAPx'), '/admin/config/capx'),
+    l(t('Map'), '/admin/config/capx/mapper'),
+    l(t($mapper->title), CAPX_TAMPER . "/edit/{$mapper->getMachineName()}"),
+
+  );
+  if ($tamper_id) {
+    $breadcrumb[] = l(t('Tamper'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper");
+  }
+  drupal_set_breadcrumb($breadcrumb);
 }

--- a/modules/capx_tamper/capx_tamper.info
+++ b/modules/capx_tamper/capx_tamper.info
@@ -1,7 +1,8 @@
 name = CAPx Tamper
 core = 7.x
-version = 7.x-1.0-dev
+version = 7.x-2.0-dev
 package = Stanford CAPx
+project = capx_tamper
 
 files[] = CapxTamper.inc
 files[] = views/views_handler_tamper_link.inc

--- a/modules/capx_tamper/capx_tamper.info
+++ b/modules/capx_tamper/capx_tamper.info
@@ -4,6 +4,7 @@ version = 7.x-1.0-dev
 package = Stanford CAPx
 
 files[] = CapxTamper.inc
+files[] = views/views_handler_tamper_link.inc
 
 dependencies[] = ctools
 dependencies[] = stanford_capx

--- a/modules/capx_tamper/capx_tamper.info
+++ b/modules/capx_tamper/capx_tamper.info
@@ -3,4 +3,6 @@ core = 7.x
 version = 7.x-1.0-dev
 package = Stanford CAPx
 
+dependencies[] = ctools
+dependencies[] = stanford_capx
 dependencies[] = feeds_tamper

--- a/modules/capx_tamper/capx_tamper.info
+++ b/modules/capx_tamper/capx_tamper.info
@@ -3,6 +3,8 @@ core = 7.x
 version = 7.x-1.0-dev
 package = Stanford CAPx
 
+files[] = CapxTamper.inc
+
 dependencies[] = ctools
 dependencies[] = stanford_capx
 dependencies[] = feeds_tamper

--- a/modules/capx_tamper/capx_tamper.info
+++ b/modules/capx_tamper/capx_tamper.info
@@ -1,0 +1,6 @@
+name = CAPx Tamper
+core = 7.x
+version = 7.x-1.0-dev
+package = Stanford CAPx
+
+dependencies[] = feeds_tamper

--- a/modules/capx_tamper/capx_tamper.install
+++ b/modules/capx_tamper/capx_tamper.install
@@ -11,17 +11,17 @@ function capx_tamper_schema() {
   $schema = array();
   $schema['capx_tamper'] = array(
     'description' => 'Table storing CAPx tamper instances.',
-//    'export' => array(
-//      'key' => 'id',
-//      'identifier' => 'capx_tamper', // Exports will be as $tamper_instalce
-//      'default hook' => 'capx_tamper_default',  // Function hook name.
-//      'api' => array(
-//        'owner' => 'capx_tamper',
-//        'api' => 'capx_tamper_default',  // Base name for api include files.
-//        'minimum_version' => 2,
-//        'current_version' => 2,
-//      ),
-//    ),
+    'export' => array(
+      'key' => 'id',
+      'identifier' => 'plugin',
+      'default hook' => 'capx_tamper_plugins',
+      'api' => array(
+        'owner' => 'capx_tamper',
+        'api' => 'capx_tamper_plugins',
+        'minimum_version' => 1,
+        'current_version' => 1,
+      ),
+    ),
     'fields' => array(
       'id' => array(
         'type' => 'varchar',

--- a/modules/capx_tamper/capx_tamper.install
+++ b/modules/capx_tamper/capx_tamper.install
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @file
+ * CAPx Tamper Install.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function capx_tamper_schema() {
+  $schema = array();
+  $schema['capx_tamper'] = array(
+    'description' => 'Table storing CAPx tamper instances.',
+//    'export' => array(
+//      'key' => 'id',
+//      'identifier' => 'capx_tamper', // Exports will be as $tamper_instalce
+//      'default hook' => 'capx_tamper_default',  // Function hook name.
+//      'api' => array(
+//        'owner' => 'capx_tamper',
+//        'api' => 'capx_tamper_default',  // Base name for api include files.
+//        'minimum_version' => 2,
+//        'current_version' => 2,
+//      ),
+//    ),
+    'fields' => array(
+      'id' => array(
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'Id of the CAPx tamper instance.',
+      ),
+      'mapper' => array(
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'Id of the CAPx importer.',
+      ),
+      'source' => array(
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The source field of the importer.',
+      ),
+      'plugin_id' => array(
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'Id of the tamper plugin.',
+      ),
+      'settings' => array(
+        'type' => 'text',
+        'size' => 'big',
+        'description' => 'A serialized array of options for a CAPx Tamper plugin.',
+        'serialize' => TRUE,
+      ),
+      'weight' => array(
+        'type' => 'int',
+        'not null' => TRUE,
+        'unsigned' => TRUE,
+        'description' => 'The weight of a plugin instance. Plugins are executed in order.',
+      ),
+      'description' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'Description of this plugin.',
+      ),
+    ),
+    'primary key' => array('id'),
+    'indexes' => array(
+      'mapper' => array('mapper'),
+    ),
+  );
+  return $schema;
+}

--- a/modules/capx_tamper/capx_tamper.install
+++ b/modules/capx_tamper/capx_tamper.install
@@ -21,17 +21,6 @@ function capx_tamper_schema() {
   $schema = array();
   $schema['capx_tamper'] = array(
     'description' => 'Table storing CAPx tamper instances.',
-    'export' => array(
-      'key' => 'id',
-      'identifier' => 'plugin',
-      'default hook' => 'capx_tamper_plugins',
-      'api' => array(
-        'owner' => 'capx_tamper',
-        'api' => 'capx_tamper_plugins',
-        'minimum_version' => 1,
-        'current_version' => 1,
-      ),
-    ),
     'fields' => array(
       'id' => array(
         'type' => 'varchar',

--- a/modules/capx_tamper/capx_tamper.install
+++ b/modules/capx_tamper/capx_tamper.install
@@ -5,16 +5,6 @@
  */
 
 /**
- * Implements hook_install().
- */
-function capx_tamper_install() {
-  db_update('system')
-    ->fields(array('weight' => -10))
-    ->condition('name', 'capx_tamper', '=')
-    ->execute();
-}
-
-/**
  * Implements hook_schema().
  */
 function capx_tamper_schema() {
@@ -38,10 +28,17 @@ function capx_tamper_schema() {
       ),
       'source' => array(
         'type' => 'varchar',
-        'length' => 128,
+        'length' => 255,
         'not null' => TRUE,
         'default' => '',
         'description' => 'The source field of the importer.',
+      ),
+      'target' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The target field of the importer.',
       ),
       'plugin_id' => array(
         'type' => 'varchar',

--- a/modules/capx_tamper/capx_tamper.install
+++ b/modules/capx_tamper/capx_tamper.install
@@ -5,6 +5,16 @@
  */
 
 /**
+ * Implements hook_install().
+ */
+function capx_tamper_install() {
+  db_update('system')
+    ->fields(array('weight' => -10))
+    ->condition('name', 'capx_tamper', '=')
+    ->execute();
+}
+
+/**
  * Implements hook_schema().
  */
 function capx_tamper_schema() {

--- a/modules/capx_tamper/capx_tamper.install
+++ b/modules/capx_tamper/capx_tamper.install
@@ -60,7 +60,7 @@ function capx_tamper_schema() {
       'weight' => array(
         'type' => 'int',
         'not null' => TRUE,
-        'unsigned' => TRUE,
+        'unsigned' => FALSE,
         'description' => 'The weight of a plugin instance. Plugins are executed in order.',
       ),
       'description' => array(

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -104,10 +104,10 @@ function capx_tamper_menu() {
  */
 function capx_tamper_mapper_load($mapper_id) {
   $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
-  if (!$mapper) {
-    drupal_not_found();
-    drupal_exit();
-  }
+//  if (!$mapper) {
+//    drupal_not_found();
+//    drupal_exit();
+//  }
   return $mapper;
 }
 
@@ -121,16 +121,12 @@ function capx_tamper_mapper_load($mapper_id) {
  *   Associative array of keys as json paths. Values as an array of targets.
  */
 function capx_tamper_get_mapper_sources(CFEntity $mapper) {
-  $sources = array();
-  foreach ($mapper->properties as $property => $path) {
-    $sources[$path][] = $property;
-  }
-
+  $sources = $mapper->properties;
   foreach ($mapper->fields as $field_key => $field_settings) {
     $field_settings = array_filter($field_settings);
     if ($field_settings) {
       $path = $field_settings[key($field_settings)];
-      $sources[$path][] = $field_key;
+      $sources[$field_key] = $path;
     }
   }
   return $sources;
@@ -174,7 +170,7 @@ function capx_tamper_entity_update($entity, $type) {
     /** @var \CAPx\Drupal\Entities\CFEntity $entity */
     $sources = capx_tamper_get_mapper_sources($entity);
     foreach ($entity->tampers as $id => $tamper) {
-      if (!isset($sources[$tamper->source])) {
+      if (!isset($sources[$tamper->target]) || $sources[$tamper->target] != $tamper->source) {
         capx_tamper_delete_instance($tamper);
       }
     }
@@ -208,31 +204,31 @@ function capx_tamper_entity_delete($entity, $type) {
  *   Single or all tampers configured.
  */
 function capx_tamper_load_tampers($conditions = array()) {
-  $items = array();
+  $disabled = variable_get('capx_tamper_disabled', array());
+
   $query = db_select('capx_tamper', 'c')
     ->fields('c');
-
   foreach ($conditions as $key => $value) {
-    $query->condition($key, $value);
-  }
-  $results = $query->execute();
-
-  while ($item = $results->fetchAssoc()) {
-    $item['settings'] = unserialize($item['settings']);
-    $items[] = (object) $item;
-  }
-
-  $disabled = variable_get('capx_tamper_disabled', array());
-  foreach ($items as &$tamper) {
-    $tamper->disabled = FALSE;
-    if (isset($disabled[$tamper->id])) {
-      $tamper->disabled = TRUE;
+    if (db_field_exists('capx_tamper', $key)) {
+      if (is_array($value)) {
+        $query->condition($key, $value, 'IN');
+      }
+      else {
+        $query->condition($key, $value);
+      }
     }
   }
+  $query->orderBy('weight', 'ASC');
+  $results = $query->execute();
 
-  usort($items, function ($a, $b) {
-    return $a->weight - $b->weight;
-  });
+  $items = array();
+  while ($item = $results->fetchAssoc()) {
+    $item['settings'] = unserialize($item['settings']);
+    if (isset($disabled[$item['id']])) {
+      $item['disabled'] = TRUE;
+    }
+    $items[] = (object) $item;
+  }
 
   return $items;
 }
@@ -259,15 +255,14 @@ function capx_tamper_save_instance($tamper) {
     return FALSE;
   }
 
-
   if (capx_tamper_load_tampers(array('id' => $tamper['id']))) {
-    drupal_write_record('capx_tamper', $tamper, 'id');
+    $success = drupal_write_record('capx_tamper', $tamper, 'id');
   }
   else {
-    drupal_write_record('capx_tamper', $tamper);
+    $success = drupal_write_record('capx_tamper', $tamper);
   }
   capx_tamper_invalidate_etags($tamper['mapper']);
-  return TRUE;
+  return $success;
 }
 
 /**
@@ -298,82 +293,6 @@ function capx_tamper_invalidate_etags($mapper_id) {
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
   $mapper = capx_tamper_mapper_load($mapper_id);
   CAPx::invalidateEtags('mapper', $mapper);
-}
-
-/**
- * Implements hook_capx_pre_update_entity_alter().
- */
-function capx_tamper_capx_pre_update_entity_alter(&$entity, &$data, EntityMapper &$mapper) {
-  $values = array(
-    'data' => $data,
-    'mapper' => $mapper,
-  );
-  capx_tamper_capx_pre_entity_create_alter($values);
-  $data = $values['data'];
-}
-
-/**
- * Implements hook_capx_pre_entity_create_alter().
- *
- * Change the entries in the $values['data'] according to the tamper plugins.
- */
-function capx_tamper_capx_pre_entity_create_alter(&$values) {
-  /** @var EntityMapper $mapper */
-  $mapper = NULL;
-  $data = array();
-  extract($values);
-  /** @var CFEntity $cfe_mapper */
-  $cfe_mapper = $mapper->getMapper();
-  // Sets an object to be used for particular tamper plugins.
-  // @see feeds_tamper_copy_callback().
-  $result = new stdClass();
-  $items = array();
-  foreach (capx_tamper_get_mapper_sources($cfe_mapper) as $path => $targets) {
-    $item = $mapper->getRemoteDataByJsonPath($data, $path);
-    if (strpos($path, '*') !== FALSE) {
-      $index = $mapper->getIndex();
-      if (isset($item[$index])) {
-        $item = $item[$index];
-      }
-    }
-
-    if (is_array($item)) {
-      if (array_filter($item)) {
-        $item = reset($item);
-      }
-      else {
-        $item = NULL;
-      }
-    }
-    $items[0][$path] = $item;
-  }
-  $result->items = $items;
-
-  // Loop through tamper plugins on the mapper.
-  foreach ($cfe_mapper->tampers as $tamper) {
-    if ($tamper->disabled) {
-      continue;
-    }
-
-    $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
-    if (function_exists($plugin['callback']) && isset($result->items[0][$tamper->source])) {
-      $path = $tamper->source;
-      $field = &$result->items[0][$path];
-
-      // Call any functions that have to alter the tamper before using
-      // the feeds tamper plugin directly.
-      $pre_callback = 'capx_tamper_' . $plugin['callback'];
-      $key = 0;
-      if (function_exists($pre_callback)) {
-        $pre_callback($result, $key, $path, $field, $tamper->settings, $tamper->source);
-      }
-
-      // Call the feeds tamper. Then set that value back into the data array.
-      $plugin['callback']($result, $key, $path, $field, $tamper->settings, $tamper->source);
-      capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
-    }
-  }
-  $values['data'] = $data;
 }
 
 /**
@@ -449,4 +368,123 @@ function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
 function capx_tamper_table_id($path) {
   $path = trim($path, '$.');
   return preg_replace("/[^A-Za-z0-9 ]/", '-', $path);
+}
+
+/**
+ * Implements hook_capx_pre_property_set_alter().
+ */
+function capx_tamper_capx_pre_property_set_alter($entity, &$data, &$property_name) {
+  capx_tamper_alter_data($entity, $data, $property_name);
+}
+
+/**
+ * Implements hook_capx_pre_map_field_alter().
+ */
+function capx_tamper_capx_pre_map_field_alter(&$entity, &$field_name, &$remote_data_paths, &$data) {
+  capx_tamper_alter_data($entity, $data, $field_name);
+}
+
+/**
+ * Alters the data object as configured from the tampers.
+ *
+ * @param object $entity
+ *   Entity to be operated on.
+ * @param array $data
+ *   Json data array.
+ * @param string $field_name
+ *   Field machine name or entity property.
+ */
+function capx_tamper_alter_data($entity, &$data, $field_name) {
+  $e = $entity->raw();
+  /** @var EntityMapper $mapper */
+  $mapper = $e->capxMapper;
+  /** @var CFEntity $cfe_mapper */
+  $cfe_mapper = $mapper->getMapper();
+
+
+  // Sets an object to be used for particular tamper plugins.
+  // @see feeds_tamper_copy_callback().
+  $result = new stdClass();
+  $items = array();
+  foreach (capx_tamper_get_mapper_sources($cfe_mapper) as $path) {
+    $item = $mapper->getRemoteDataByJsonPath($data, $path);
+    if (strpos($path, '*') !== FALSE) {
+      $index = $mapper->getIndex();
+      if (isset($item[$index])) {
+        $item = $item[$index];
+      }
+    }
+
+    if (is_array($item)) {
+      if (array_filter($item)) {
+        $item = reset($item);
+      }
+      else {
+        $item = NULL;
+      }
+    }
+    $items[0][$path] = $item;
+  }
+  $result->items = $items;
+
+  // Loop through tamper plugins on the mapper.
+  foreach ($cfe_mapper->tampers as $tamper) {
+    if ($tamper->disabled || $tamper->target !== $field_name) {
+      continue;
+    }
+    $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
+    if (function_exists($plugin['callback']) && isset($result->items[0][$tamper->source])) {
+      $path = $tamper->source;
+      $field = &$result->items[0][$path];
+
+      // Call any functions that have to alter the tamper before using
+      // the feeds tamper plugin directly.
+      $pre_callback = 'capx_tamper_' . $plugin['callback'];
+      $key = 0;
+      if (function_exists($pre_callback)) {
+        $pre_callback($result, $key, $path, $field, $tamper->settings, $tamper->source);
+      }
+      // Call the feeds tamper. Then set that value back into the data array.
+      $plugin['callback']($result, $key, $path, $field, $tamper->settings, $tamper->source);
+      capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
+    }
+  }
+}
+
+/**
+ * Add a validation function to the import form.
+ *
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State Array.
+ */
+function capx_tamper_form_stanford_capx_preset_import_form_alter(&$form, &$form_state) {
+  $form['#validate'][] = "capx_tamper_form_stanford_capx_preset_import_form_alter_validate";
+}
+
+/**
+ * Do some validation prior to saving.
+ *
+ * @param array $form
+ *   Form Array.
+ * @param array $form_state
+ *   Form State Array.
+ */
+function capx_tamper_form_stanford_capx_preset_import_form_alter_validate($form, &$form_state) {
+  $code = $form_state['values']['code'];
+  $cfe = entity_import('capx_cfe', $code);
+
+  if (isset($cfe->tampers)) {
+    foreach ($cfe->tampers as $tamper) {
+      // Validity check.
+      list($mapper_id) = explode('-', $tamper['id']);
+      if ($mapper_id !== $tamper['mapper'] || $mapper_id !== $cfe->machine_name) {
+        form_set_error('code', t('Invalid CAPx Mapper "%mapper" in tamper plugin "%description"', array(
+          '%mapper' => $mapper_id,
+          '%description' => $tamper['description'],
+        )));
+      }
+    }
+  }
 }

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -121,16 +121,27 @@ function capx_tamper_get_mapper_sources(CFEntity $mapper) {
 }
 
 /**
- * Implements hook_entity_delete().
- *
- * Deletes any CAPx Tamper plugins when the mapper is deleted.
+ * Implements hook_entity_load().
  */
-function capx_tamper_entity_delete($entity, $type) {
+function capx_tamper_entity_load($entities, $type) {
+  if ($type == 'capx_cfe') {
+    foreach ($entities as &$entity) {
+      if ($entity->type == 'mapper') {
+        $entity->tampers = capx_tamper_load_tampers(array('mapper' => $entity->machine_name));
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function capx_tamper_entity_insert($entity, $type) {
   if ($type == 'capx_cfe' && $entity->type == 'mapper') {
-    /** @var \CAPx\Drupal\Entities\CFEntity $entity */
-    $tampers = capx_tamper_load_tampers(array('mapper' => $entity->getMachineName()));
-    foreach ($tampers as $tamper) {
-      capx_tamper_delete_instance($tamper);
+    if (isset($entity->tampers) && $entity->tampers) {
+      foreach ($entity->tampers as $tamper) {
+        capx_tamper_save_instance($tamper);
+      }
     }
   }
 }
@@ -145,11 +156,24 @@ function capx_tamper_entity_update($entity, $type) {
   if ($type == 'capx_cfe' && $entity->type == 'mapper') {
     /** @var \CAPx\Drupal\Entities\CFEntity $entity */
     $sources = capx_tamper_get_mapper_sources($entity);
-    $tampers = capx_tamper_load_tampers(array('mapper' => $entity->getMachineName()));
-    foreach ($tampers as $id => $tamper) {
+    foreach ($entity->tampers as $id => $tamper) {
       if (!isset($sources[$tamper->source])) {
         capx_tamper_delete_instance($tamper);
       }
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_delete().
+ *
+ * Deletes any CAPx Tamper plugins when the mapper is deleted.
+ */
+function capx_tamper_entity_delete($entity, $type) {
+  if ($type == 'capx_cfe' && $entity->type == 'mapper') {
+    /** @var \CAPx\Drupal\Entities\CFEntity $entity */
+    foreach ($entity->tampers as $tamper) {
+      capx_tamper_delete_instance($tamper);
     }
   }
 }
@@ -286,7 +310,7 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   $result->items = $items;
 
   // Loop through tamper plugins on the mapper.
-  foreach (capx_tamper_load_tampers(array('mapper' => $cfe_mapper->machine_name)) as $tamper) {
+  foreach ($cfe_mapper->tampers as $tamper) {
     if ($tamper->disabled) {
       continue;
     }

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -4,7 +4,7 @@
  * CAPx Tamper Module.
  */
 
-define('CAPX_TAMPER', 'admin/config/capx/mapper/edit');
+define('CAPX_TAMPER', 'admin/config/capx/mapper');
 
 /**
  * Implements hook_ctools_plugin_api().
@@ -20,10 +20,10 @@ function capx_tamper_ctools_plugin_api($owner, $api) {
  */
 function capx_tamper_menu() {
   $items = array();
-  $items[CAPX_TAMPER . '/%/tamper'] = array(
+  $items[CAPX_TAMPER . '/%capx_tamper_mapper/tamper'] = array(
     'title' => 'Tampers',
     'page callback' => 'capx_tamper_list',
-    'page arguments' => array(5),
+    'page arguments' => array(4),
     'file' => 'capx_tamper.forms.inc',
     'access arguments' => array('administer capx'),
     'type' => MENU_CALLBACK,
@@ -32,7 +32,7 @@ function capx_tamper_menu() {
   $items[CAPX_TAMPER . '/%/tamper/add/%'] = array(
     'title' => 'Add Tamper',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('capx_tamper_add', 5, 8),
+    'page arguments' => array('capx_tamper_add', 4, 7),
     'file' => 'capx_tamper.forms.inc',
     'access arguments' => array('administer capx'),
     'type' => MENU_LOCAL_ACTION,
@@ -41,7 +41,7 @@ function capx_tamper_menu() {
   $items[CAPX_TAMPER . '/%/tamper/%/edit'] = array(
     'title' => 'Tampers',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('capx_tamper_edit', 5, 7),
+    'page arguments' => array('capx_tamper_edit', 4, 6),
     'file' => 'capx_tamper.forms.inc',
     'access arguments' => array('administer capx'),
     'type' => MENU_CALLBACK,
@@ -50,13 +50,37 @@ function capx_tamper_menu() {
   $items[CAPX_TAMPER . '/%/tamper/%/delete'] = array(
     'title' => 'Tampers',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('capx_tamper_delete', 5, 7),
+    'page arguments' => array('capx_tamper_delete', 4, 6),
     'file' => 'capx_tamper.forms.inc',
     'access arguments' => array('administer capx'),
     'type' => MENU_CALLBACK,
   );
 
   return $items;
+}
+
+function capx_tamper_mapper_load($mapper_id) {
+  $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
+  if (!$mapper) {
+    drupal_not_found();
+    drupal_exit();
+  }
+  return $mapper;
+}
+
+function capx_tamper_get_mapper_sources($mapper) {
+  $sources = array();
+  foreach ($mapper->fields as $field_key => $field_settings) {
+    $field_settings = array_filter($field_settings);
+    if ($field_settings) {
+      $path = $field_settings[key($field_settings)];
+      $sources[$path][] = $field_key;
+    }
+  }
+  foreach ($mapper->properties as $property => $path) {
+    $sources[$path][] = $property;
+  }
+  return $sources;
 }
 
 /**
@@ -130,38 +154,25 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   $cfe_mapper = $mapper->getMapper();
 
   foreach (capx_tamper_load_tampers(array('mapper' => $cfe_mapper->machine_name)) as $tamper) {
-    $path = NULL;
-    $plugin = feeds_tamper_get_plugin($tamper['plugin_id']);
+    $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
     if (function_exists($plugin['callback'])) {
-
-      if (isset($cfe_mapper->fields[$tamper->source])) {
-        $temp = array_filter($cfe_mapper->fields[$tamper->source]);
-        $path = $temp[key($temp)];
-      }
-      else {
-        if (isset($cfe_mapper->properties[$tamper->source])) {
-          $path = $cfe_mapper->properties[$tamper->source];
-        }
-      }
-
-      if ($path) {
-        $field = $mapper->getRemoteDataByJsonPath($data, $path);
-        if (strpos($path, '*') !== FALSE) {
-          if (isset($field[$mapper->getIndex()])) {
-            $field = $field[$mapper->getIndex()];
-          }
-          else {
-            $field = NULL;
-          }
+      $path = $tamper->source;
+      $field = $mapper->getRemoteDataByJsonPath($data, $path);
+      if (strpos($path, '*') !== FALSE) {
+        if (isset($field[$mapper->getIndex()])) {
+          $field = $field[$mapper->getIndex()];
         }
         else {
-          $field = reset($field);
+          $field = NULL;
         }
+      }
+      else {
+        $field = reset($field);
+      }
 
-        if ($field) {
-          $plugin['callback'](NULL, NULL, NULL, $field, $tamper->settings, $tamper->source);
-          capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
-        }
+      if ($field) {
+        $plugin['callback'](NULL, NULL, NULL, $field, $tamper->settings, $tamper->source);
+        capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
       }
     }
   }
@@ -189,21 +200,61 @@ function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
 
   $paths = explode('.', $path);
   $piece = array_shift($paths);
-  switch ($piece) {
-    case '$':
-      capx_tamper_set_data_by_json_path($data, implode('.', $paths), $value);
-      break;
 
-    case '*':
-      capx_tamper_set_data_by_json_path($data[$index], implode('.', $paths), $value);
-      break;
-
-    default:
-      if (isset($data[$piece])) {
-        capx_tamper_set_data_by_json_path($data[$piece], implode('.', $paths), $value);
-      }
-      break;
+  // Beginning of the JSON path.
+  if ($piece == '$') {
+    $piece = array_shift($paths);
   }
+
+  // Wildcard, replace the piece with the index value.
+  if ($piece == '*') {
+    $piece = $index;
+  }
+
+  capx_tamper_set_data_by_json_path($data[$piece], implode('.', $paths), $value);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function capx_tamper_form_stanford_capx_mapper_form_alter(&$form, &$form_state, $form_id) {
+  $mapper_name = FALSE;
+
+  if ($form['naming']['machine-name']['#default_value']) {
+    $mapper_name = $form['naming']['machine-name']['#default_value'];
+  }
+
+  $form['tampers'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Tamper'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#weight' => 1,
+    '#tree' => TRUE,
+  );
+
+  // Move the submit buttons to the bottom.
+  $form['actions']['#weight'] = 100;
+
+  if (!$mapper_name) {
+    $form['tampers']['info'] = array(
+      '#markup' => t('Configure and save the mapper before configuring tampers.'),
+    );
+    return;
+  }
+
+  $form['tampers']['intro'] = array(
+    '#markup' => "<p>" . t("Tampers allow you to manipulate items from the API before saving the data. For example, you can create a tamper that would strip html tags, or replace strings etc.") . "<p>",
+  );
+
+  $cta = "<br/><p>";
+  $cta .= l(t('Manage Tampers'), CAPX_TAMPER . "/$mapper_name/tamper", array("attributes" => array("class" => 'button')));
+  $cta .= "</p>";
+  $cta .= "<span><em>" . t("Clicking this button will navigate you away to a new page. Please save your work first.") . "</em></span>";
+
+  $form['tampers']['cta'] = array(
+    '#markup' => $cta,
+  );
 }
 
 

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -153,6 +153,17 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   /** @var \CAPx\Drupal\Entities\CFEntity $cfe_mapper */
   $cfe_mapper = $mapper->getMapper();
 
+  $result = new stdClass();
+  $items = array();
+  foreach (capx_tamper_get_mapper_sources($cfe_mapper) as $path => $targets) {
+    $items[0][$path] = $mapper->getRemoteDataByJsonPath($data, $path);
+    if (strpos($path, '*') !== FALSE) {
+      $items[0][$path] = $items[0][$path][$mapper->getIndex()];
+    }
+  }
+  $result->items = $items;
+
+
   foreach (capx_tamper_load_tampers(array('mapper' => $cfe_mapper->machine_name)) as $tamper) {
     $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
     if (function_exists($plugin['callback'])) {
@@ -171,7 +182,7 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
       }
 
       if ($field) {
-        $plugin['callback'](NULL, NULL, NULL, $field, $tamper->settings, $tamper->source);
+        $plugin['callback']($result, 0, $path, $field, $tamper->settings, $tamper->source);
         capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
       }
     }
@@ -194,6 +205,9 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
  */
 function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
   if (!is_array($data)) {
+    if (is_array($value)) {
+      $value = reset($value);
+    }
     $data = $value;
     return;
   }

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -438,49 +438,6 @@ function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function capx_tamper_form_stanford_capx_mapper_form_alter(&$form, &$form_state, $form_id) {
-  $mapper_name = FALSE;
-
-  if ($form['naming']['machine-name']['#default_value']) {
-    $mapper_name = $form['naming']['machine-name']['#default_value'];
-  }
-
-  $form['tampers'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Tamper'),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
-    '#weight' => 1,
-    '#tree' => TRUE,
-  );
-
-  // Move the submit buttons to the bottom.
-  $form['actions']['#weight'] = 100;
-
-  if (!$mapper_name) {
-    $form['tampers']['info'] = array(
-      '#markup' => t('Configure and save the mapper before configuring tampers.'),
-    );
-    return;
-  }
-
-  $form['tampers']['intro'] = array(
-    '#markup' => "<p>" . t("Tampers allow you to manipulate items from the API before saving the data. For example, you can create a tamper that would strip html tags, or replace strings etc.") . "<p>",
-  );
-
-  $cta = "<br/><p>";
-  $cta .= l(t('Manage "!name" Tampers', array('!name' => $form_state['build_info']['args'][0]->title)), CAPX_TAMPER . "/$mapper_name/tamper", array("attributes" => array("class" => 'button')));
-  $cta .= "</p>";
-  $cta .= "<span><em>" . t("Clicking this button will navigate you away to a new page. Please save your work first.") . "</em></span>";
-
-  $form['tampers']['cta'] = array(
-    '#markup' => $cta,
-  );
-}
-
-/**
  * Creates an HTML id/class attribute name.
  *
  * @param string $path

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -94,6 +94,20 @@ function capx_tamper_menu() {
 }
 
 /**
+ * Loader for menu & pages.
+ *
+ * @param string $mapper_id
+ *   Machine name of the Capx Mapper.
+ *
+ * @return \CAPx\Drupal\Entities\CFEntity
+ *   CAPx Mapper.
+ */
+function capx_tamper_mapper_load($mapper_id) {
+  $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
+  return $mapper;
+}
+
+/**
  * Takes the configurations of the CAPx Mapper and gives the available sources.
  *
  * @param CFEntity $mapper
@@ -229,7 +243,7 @@ function capx_tamper_save_instance($tamper) {
 
   // Validity check.
   list($mapper_id) = explode('-', $tamper['id']);
-  if ($mapper_id != $tamper['mapper'] || !capx_cfe_load_by_machine_name($mapper_id, 'mapper')) {
+  if ($mapper_id != $tamper['mapper'] || !capx_tamper_mapper_load($mapper_id)) {
     drupal_set_message(t('Invalid CAPx Mapper "%mapper" in tamper plugin "%description"', array(
       '%mapper' => $mapper_id,
       '%description' => $tamper['description'],
@@ -273,7 +287,7 @@ function capx_tamper_delete_instance($tamper) {
  */
 function capx_tamper_invalidate_etags($mapper_id) {
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
-  $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
+  $mapper = capx_tamper_mapper_load($mapper_id);
   CAPx::invalidateEtags('mapper', $mapper);
 }
 
@@ -382,6 +396,7 @@ function capx_tamper_alter_data($entity, &$data, $field_name) {
   $mapper = $e->capxMapper;
   /** @var CFEntity $cfe_mapper */
   $cfe_mapper = $mapper->getMapper();
+
 
   // Sets an object to be used for particular tamper plugins.
   // @see feeds_tamper_copy_callback().

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -1,0 +1,195 @@
+<?php
+/**
+ * @file
+ * CAPx Tamper Module.
+ */
+
+define('CAPX_TAMPER', 'admin/config/capx/mapper/edit');
+
+/**
+ * Implements hook_menu().
+ */
+function capx_tamper_menu() {
+  $items = array();
+  $items[CAPX_TAMPER . '/%/tamper'] = array(
+    'title' => 'Tampers',
+    'page callback' => 'capx_tamper_list',
+    'page arguments' => array(5),
+    'file' => 'capx_tamper.forms.inc',
+    'access arguments' => array('administer capx'),
+    'type' => MENU_CALLBACK,
+  );
+
+  $items[CAPX_TAMPER . '/%/tamper/add/%'] = array(
+    'title' => 'Add Tamper',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('capx_tamper_add', 5, 8),
+    'file' => 'capx_tamper.forms.inc',
+    'access arguments' => array('administer capx'),
+    'type' => MENU_LOCAL_ACTION,
+  );
+
+  $items[CAPX_TAMPER . '/%/tamper/%/edit'] = array(
+    'title' => 'Tampers',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('capx_tamper_edit', 5, 7),
+    'file' => 'capx_tamper.forms.inc',
+    'access arguments' => array('administer capx'),
+    'type' => MENU_CALLBACK,
+  );
+
+  $items[CAPX_TAMPER . '/%/tamper/%/delete'] = array(
+    'title' => 'Tampers',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('capx_tamper_delete', 5, 7),
+    'file' => 'capx_tamper.forms.inc',
+    'access arguments' => array('administer capx'),
+    'type' => MENU_CALLBACK,
+  );
+  return $items;
+}
+
+
+function capx_tamper_load_tamper($id) {
+  $query = db_select('capx_tamper', 'c')
+    ->fields('c')
+    ->condition('id', $id)
+    ->execute()
+    ->fetchAssoc();
+  if ($query) {
+    $query['settings'] = unserialize($query['settings']);
+    return $query;
+  }
+  return FALSE;
+}
+
+
+function capx_tamper_save_instance($tamper) {
+  if (capx_tamper_load_tamper($tamper['id'])) {
+    drupal_write_record('capx_tamper', $tamper, 'id');
+  }
+  else {
+    drupal_write_record('capx_tamper', $tamper);
+  }
+}
+
+function capx_tamper_delete_instance($tamper) {
+  db_delete('capx_tamper')
+    ->condition('id', $tamper['id'])
+    ->execute();
+}
+
+/**
+ * @param string $mapper_id
+ *   Machine name of the mapper.
+ * @param null|string $source
+ *   The field name/property if desired to get that particular set of tampers.
+ *
+ * @return array
+ *   All active tampers for the given parameters.
+ */
+function capx_tamper_get_tampers($mapper_id, $source = NULL) {
+  $tampers = array();
+  $query = db_select('capx_tamper', 'c');
+  $query->fields('c');
+  $query->condition('mapper', $mapper_id);;
+  if ($source) {
+    $query->condition('source', $source);
+  }
+  $query->orderBy('weight', 'ASC');
+  $results = $query->execute();
+
+  while ($row = $results->fetchAssoc()) {
+    $row['settings'] = unserialize($row['settings']);
+    $tampers[$row['weight']] = $row;
+  }
+  return $tampers;
+}
+
+/**
+ * Implements hook_capx_pre_entity_create_alter().
+ */
+function capx_tamper_capx_pre_entity_create_alter(&$values) {
+  /** @var \CAPx\Drupal\Mapper\EntityMapper $mapper */
+  $mapper = NULL;
+  $data = array();
+  extract($values);
+  /** @var \CAPx\Drupal\Entities\CFEntity $cfe_mapper */
+  $cfe_mapper = $mapper->getMapper();
+
+  $tampers = capx_tamper_get_tampers($cfe_mapper->machine_name);
+
+  foreach ($tampers as $tamper) {
+    $path = NULL;
+    $plugin = feeds_tamper_get_plugin($tamper['plugin_id']);
+    if (function_exists($plugin['callback'])) {
+
+      if (isset($cfe_mapper->fields[$tamper['source']])) {
+        $temp = array_filter($cfe_mapper->fields[$tamper['source']]);
+        $path = $temp[key($temp)];
+      }
+      else {
+        if (isset($cfe_mapper->properties[$tamper['source']])) {
+          $path = $cfe_mapper->properties[$tamper['source']];
+        }
+      }
+
+      if ($path) {
+        $field = $mapper->getRemoteDataByJsonPath($data, $path);
+        if (strpos($path, '*') !== FALSE) {
+          if (isset($field[$mapper->getIndex()])) {
+            $field = $field[$mapper->getIndex()];
+          }
+          else {
+            $field = NULL;
+          }
+        }
+        else {
+          $field = reset($field);
+        }
+
+        if ($field) {
+          $plugin['callback'](NULL, NULL, NULL, $field, $tamper['settings'], $tamper['source']);
+          capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
+        }
+      }
+    }
+  }
+
+  $values['data'] = $data;
+}
+
+function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
+  if (!is_array($data)) {
+    $data = $value;
+    return;
+  }
+
+  $paths = explode('.', $path);
+  $piece = array_shift($paths);
+  switch ($piece) {
+    case '$':
+      capx_tamper_set_data_by_json_path($data, implode('.', $paths), $value);
+      break;
+
+    case '*':
+      capx_tamper_set_data_by_json_path($data[$index], implode('.', $paths), $value);
+      break;
+
+    default:
+      if (isset($data[$piece])) {
+        capx_tamper_set_data_by_json_path($data[$piece], implode('.', $paths), $value);
+      }
+      break;
+  }
+}
+
+
+/**
+ * Implements hook_node_insert().
+ */
+function capx_tamper_node_insert($node) {
+  // For quick deletion during development period.
+  // todo: Delete after finished developing.
+  node_delete($node->nid);
+}

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -1,8 +1,12 @@
 <?php
+
 /**
  * @file
  * CAPx Tamper Module.
  */
+
+use \CAPx\Drupal\Util\CAPx;
+use \CAPx\Drupal\Entities\CFEntity;
 
 define('CAPX_TAMPER', 'admin/config/capx/mapper');
 
@@ -93,13 +97,13 @@ function capx_tamper_mapper_load($mapper_id) {
 /**
  * Takes the configurations of the CAPx Mapper and gives the available sources.
  *
- * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ * @param CFEntity $mapper
  *   CAPx Mapper to collect available sources.
  *
  * @return array
  *   Associative array of keys as json paths. Values as an array of targets.
  */
-function capx_tamper_get_mapper_sources($mapper) {
+function capx_tamper_get_mapper_sources(CFEntity $mapper) {
   $sources = array();
   foreach ($mapper->fields as $field_key => $field_settings) {
     $field_settings = array_filter($field_settings);
@@ -122,9 +126,10 @@ function capx_tamper_get_mapper_sources($mapper) {
 function capx_tamper_entity_delete($entity, $type) {
   if ($type == 'capx_cfe' && $entity->type == 'mapper') {
     /** @var \CAPx\Drupal\Entities\CFEntity $entity */
-    db_delete('capx_tamper')
-      ->condition('mapper', $entity->getMachineName())
-      ->execute();
+    $tampers = capx_tamper_load_tampers(array('mapper' => $entity->getMachineName()));
+    foreach ($tampers as $tamper) {
+      capx_tamper_delete_instance($tamper);
+    }
   }
 }
 
@@ -168,6 +173,14 @@ function capx_tamper_load_tampers($conditions = array()) {
     $items = ctools_export_load_object('capx_tamper');
   }
 
+  $disabled = variable_get('capx_tamper_disabled', array());
+  foreach ($items as &$tamper) {
+    $tamper->disabled = FALSE;
+    if (isset($disabled[$tamper->id])) {
+      $tamper->disabled = TRUE;
+    }
+  }
+
   usort($items, function ($a, $b) {
     return $a->weight - $b->weight;
   });
@@ -188,6 +201,7 @@ function capx_tamper_save_instance($tamper) {
   else {
     drupal_write_record('capx_tamper', $tamper);
   }
+  capx_tamper_invalidate_etags($tamper->mapper);
 }
 
 /**
@@ -201,6 +215,35 @@ function capx_tamper_delete_instance($tamper) {
     ->condition('id', $tamper->id)
     ->condition('mapper', $tamper->mapper)
     ->execute();
+
+  $disabled = variable_get('capx_tamper_disabled', array());
+  unset($disabled[$tamper->id]);
+  variable_set('capx_tamper_disabled', $disabled);
+  capx_tamper_invalidate_etags($tamper->mapper);
+}
+
+/**
+ * Invalidates etags when a tamper is created, edited, or deleted.
+ *
+ * @param string $mapper_id
+ *   Machine name of the mapper to invalidate.
+ */
+function capx_tamper_invalidate_etags($mapper_id) {
+  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+  $mapper = capx_tamper_mapper_load($mapper_id);
+  CAPx::invalidateEtags('mapper', $mapper);
+}
+
+/**
+ * Implements hook_capx_pre_update_entity_alter().
+ */
+function capx_tamper_capx_pre_update_entity_alter(&$entity, &$data, CFEntity &$mapper) {
+  $values = array(
+    'data' => $data,
+    'mapper' => $mapper,
+  );
+  capx_tamper_capx_pre_entity_create_alter($values);
+  $data = $values['data'];
 }
 
 /**
@@ -213,18 +256,18 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   $mapper = NULL;
   $data = array();
   extract($values);
-  /** @var \CAPx\Drupal\Entities\CFEntity $cfe_mapper */
+  /** @var CFEntity $cfe_mapper */
   $cfe_mapper = $mapper->getMapper();
-
-
   // Sets an object to be used for particular tamper plugins.
   // @see feeds_tamper_copy_callback().
   $result = new stdClass();
   $items = array();
   foreach (capx_tamper_get_mapper_sources($cfe_mapper) as $path => $targets) {
     $item = $mapper->getRemoteDataByJsonPath($data, $path);
-    if (strpos($path, '*') !== FALSE && isset($items[0][$path][$mapper->getIndex()])) {
-      $items[0][$path] = $items[0][$path][$mapper->getIndex()];
+    if (strpos($path, '*') !== FALSE) {
+      if (isset($items[0][$path][$mapper->getIndex()])) {
+        $items[0][$path] = $items[0][$path][$mapper->getIndex()];
+      }
     }
     if (is_array($item) && count($item)) {
       $item = reset($item);
@@ -233,41 +276,28 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   }
   $result->items = $items;
 
-
   // Loop through tamper plugins on the mapper.
   foreach (capx_tamper_load_tampers(array('mapper' => $cfe_mapper->machine_name)) as $tamper) {
+    if ($tamper->disabled) {
+      continue;
+    }
+
     $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
-    if (function_exists($plugin['callback'])) {
+    if (function_exists($plugin['callback']) && isset($result->items[0][$tamper->source])) {
       $path = $tamper->source;
-      $field = $mapper->getRemoteDataByJsonPath($data, $path);
+      $field = $result->items[0][$path];
 
-      // Gets the index item.
-      if (strpos($path, '*') !== FALSE) {
-        if (isset($field[$mapper->getIndex()])) {
-          $field = $field[$mapper->getIndex()];
-        }
-        else {
-          $field = NULL;
-        }
-      }
-      else {
-        $field = reset($field);
+      // Call any functions that have to alter the tamper before using
+      // the feeds tamper plugin directly.
+      $pre_callback = 'capx_tamper_' . $plugin['callback'];
+      $key = 0;
+      if (function_exists($pre_callback)) {
+        $pre_callback($result, $key, $path, $field, $tamper->settings, $tamper->source);
       }
 
-      if ($field) {
-
-        // Call any functions that have to alter the tamper before using
-        // the feeds tamper plugin directly.
-        $pre_callback = 'capx_tamper_' . $plugin['callback'];
-        $key = 0;
-        if (function_exists($pre_callback)) {
-          $pre_callback($result, $key, $path, $field, $tamper->settings, $tamper->source);
-        }
-
-        // Call the feeds tamper. Then set that value back into the data array.
-        $plugin['callback']($result, $key, $path, $field, $tamper->settings, $tamper->source);
-        capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
-      }
+      // Call the feeds tamper. Then set that value back into the data array.
+      $plugin['callback']($result, $key, $path, $field, $tamper->settings, $tamper->source);
+      capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
     }
   }
 
@@ -314,21 +344,15 @@ function capx_tamper_feeds_tamper_copy_callback(&$result, &$item_key, &$path, &$
  *   For wildcard items, change the correct indexed item.
  */
 function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
+  $path = trim($path, '$.');
+
   $paths = explode('.', $path);
-
-  // End of path.
-  if (count($paths) == 1) {
-    if (isset($data[$path])) {
-      $data[$path] = $value;
-      return;
-    }
-  }
-
   $piece = array_shift($paths);
 
-  // Beginning of the JSON path.
-  if ($piece == '$') {
-    $piece = array_shift($paths);
+  // End of path.
+  if (!$paths && isset($data[$piece])) {
+    $data[$piece] = $value;
+    return;
   }
 
   // Wildcard, replace the piece with the index value.

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -20,37 +20,38 @@ function capx_tamper_ctools_plugin_api($owner, $api) {
  */
 function capx_tamper_menu() {
   $items = array();
+
   $items[CAPX_TAMPER . '/%capx_tamper_mapper/tamper'] = array(
     'title' => 'Tampers',
     'page callback' => 'capx_tamper_list',
     'page arguments' => array(4),
     'file' => 'capx_tamper.forms.inc',
     'access arguments' => array('administer capx'),
-    'type' => MENU_CALLBACK,
+    'type' => MENU_NORMAL_ITEM,
   );
 
-  $items[CAPX_TAMPER . '/%/tamper/add/%'] = array(
+  $items[CAPX_TAMPER . '/%capx_tamper_mapper/tamper/add/%'] = array(
     'title' => 'Add Tamper',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('capx_tamper_add', 4, 7),
-    'file' => 'capx_tamper.forms.inc',
-    'access arguments' => array('administer capx'),
-    'type' => MENU_LOCAL_ACTION,
-  );
-
-  $items[CAPX_TAMPER . '/%/tamper/%/edit'] = array(
-    'title' => 'Tampers',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('capx_tamper_edit', 4, 6),
+    'page callback' => 'capx_tamper_build_form',
+    'page arguments' => array(6, 4, 7),
     'file' => 'capx_tamper.forms.inc',
     'access arguments' => array('administer capx'),
     'type' => MENU_CALLBACK,
   );
 
-  $items[CAPX_TAMPER . '/%/tamper/%/delete'] = array(
+  $items[CAPX_TAMPER . '/%capx_tamper_mapper/tamper/%/edit'] = array(
     'title' => 'Tampers',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('capx_tamper_delete', 4, 6),
+    'page callback' => 'capx_tamper_build_form',
+    'page arguments' => array(7, 4, 6),
+    'file' => 'capx_tamper.forms.inc',
+    'access arguments' => array('administer capx'),
+    'type' => MENU_CALLBACK,
+  );
+
+  $items[CAPX_TAMPER . '/%capx_tamper_mapper/tamper/%/delete'] = array(
+    'title' => 'Tampers',
+    'page callback' => 'capx_tamper_build_form',
+    'page arguments' => array(7, 4, 6),
     'file' => 'capx_tamper.forms.inc',
     'access arguments' => array('administer capx'),
     'type' => MENU_CALLBACK,
@@ -103,6 +104,8 @@ function capx_tamper_get_mapper_sources($mapper) {
 
 /**
  * Implements hook_entity_delete().
+ *
+ * Deletes any CAPx Tamper plugins when the mapper is deleted.
  */
 function capx_tamper_entity_delete($entity, $type) {
   if ($type == 'capx_cfe' && $entity->type == 'mapper') {
@@ -115,6 +118,9 @@ function capx_tamper_entity_delete($entity, $type) {
 
 /**
  * Implements hook_entity_update().
+ *
+ * If the source does not exist after saving the mapper, delete any CAPx Tamper
+ * plugins that are attached.
  */
 function capx_tamper_entity_update($entity, $type) {
   if ($type == 'capx_cfe' && $entity->type == 'mapper') {
@@ -179,6 +185,8 @@ function capx_tamper_delete_instance($tamper) {
 
 /**
  * Implements hook_capx_pre_entity_create_alter().
+ *
+ * Change the entries in the $values['data'] according to the tamper plugins.
  */
 function capx_tamper_capx_pre_entity_create_alter(&$values) {
   /** @var \CAPx\Drupal\Mapper\EntityMapper $mapper */
@@ -188,6 +196,9 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   /** @var \CAPx\Drupal\Entities\CFEntity $cfe_mapper */
   $cfe_mapper = $mapper->getMapper();
 
+
+  // Sets an object to be used for particular tamper plugins.
+  // @see feeds_tamper_copy_callback().
   $result = new stdClass();
   $items = array();
   foreach (capx_tamper_get_mapper_sources($cfe_mapper) as $path => $targets) {
@@ -198,17 +209,19 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
     if (is_array($item) && count($item)) {
       $item = reset($item);
     }
-
     $items[0][$path] = $item;
   }
   $result->items = $items;
 
 
+  // Loop through tamper plugins on the mapper.
   foreach (capx_tamper_load_tampers(array('mapper' => $cfe_mapper->machine_name)) as $tamper) {
     $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
     if (function_exists($plugin['callback'])) {
       $path = $tamper->source;
       $field = $mapper->getRemoteDataByJsonPath($data, $path);
+
+      // Gets the index item.
       if (strpos($path, '*') !== FALSE) {
         if (isset($field[$mapper->getIndex()])) {
           $field = $field[$mapper->getIndex()];
@@ -223,13 +236,15 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
 
       if ($field) {
 
+        // Call any functions that have to alter the tamper before using
+        // the feeds tamper plugin directly.
         $pre_callback = 'capx_tamper_' . $plugin['callback'];
         $key = 0;
         if (function_exists($pre_callback)) {
           $pre_callback($result, $key, $path, $field, $tamper->settings, $tamper->source);
         }
 
-
+        // Call the feeds tamper. Then set that value back into the data array.
         $plugin['callback']($result, $key, $path, $field, $tamper->settings, $tamper->source);
         capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
       }
@@ -280,6 +295,7 @@ function capx_tamper_feeds_tamper_copy_callback(&$result, &$item_key, &$path, &$
  */
 function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
   $paths = explode('.', $path);
+
   // End of path.
   if (count($paths) == 1) {
     if (isset($data[$path])) {
@@ -287,6 +303,7 @@ function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
       return;
     }
   }
+
   $piece = array_shift($paths);
 
   // Beginning of the JSON path.
@@ -345,14 +362,4 @@ function capx_tamper_form_stanford_capx_mapper_form_alter(&$form, &$form_state, 
   $form['tampers']['cta'] = array(
     '#markup' => $cta,
   );
-}
-
-
-/**
- * Implements hook_node_insert().
- */
-function capx_tamper_node_insert($node) {
-  // For quick deletion during development period.
-  // todo: Delete after finished developing.
-  node_delete($node->nid);
 }

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -154,10 +154,12 @@ function capx_tamper_entity_load($entities, $type) {
  */
 function capx_tamper_entity_insert($entity, $type) {
   if ($type == 'capx_cfe' && $entity->type == 'mapper' && isset($entity->tampers)) {
+    /** @var CFEntity $entity */
     foreach ($entity->tampers as $tamper) {
+      $tamper = (array) $tamper;
+      $tamper['mapper'] = $entity->machine_name;
       capx_tamper_save_instance($tamper);
     }
-
   }
 }
 
@@ -206,12 +208,18 @@ function capx_tamper_entity_delete($entity, $type) {
  *   Single or all tampers configured.
  */
 function capx_tamper_load_tampers($conditions = array()) {
-  ctools_include('export');
-  if ($conditions) {
-    $items = ctools_export_load_object('capx_tamper', 'conditions', $conditions);
+  $items = array();
+  $query = db_select('capx_tamper', 'c')
+    ->fields('c');
+
+  foreach ($conditions as $key => $value) {
+    $query->condition($key, $value);
   }
-  else {
-    $items = ctools_export_load_object('capx_tamper');
+  $results = $query->execute();
+
+  while ($item = $results->fetchAssoc()) {
+    $item['settings'] = unserialize($item['settings']);
+    $items[] = (object) $item;
   }
 
   $disabled = variable_get('capx_tamper_disabled', array());
@@ -232,17 +240,34 @@ function capx_tamper_load_tampers($conditions = array()) {
 /**
  * Saves the tamper plugin and settings.
  *
- * @param object $tamper
+ * @param object|array $tamper
  *   CAPx Tamper object.
+ *
+ * @return bool
+ *   TRUE if successful. FALSE otherwise.
  */
 function capx_tamper_save_instance($tamper) {
-  if (capx_tamper_load_tampers(array('id' => $tamper->id))) {
+  $tamper = (array) $tamper;
+
+  // Validity check.
+  list($mapper_id) = explode('-', $tamper['id']);
+  if ($mapper_id != $tamper['mapper'] || !capx_tamper_mapper_load($mapper_id)) {
+    drupal_set_message(t('Invalid CAPx Mapper "%mapper" in tamper plugin "%description"', array(
+      '%mapper' => $mapper_id,
+      '%description' => $tamper['description'],
+    )), 'error');
+    return FALSE;
+  }
+
+
+  if (capx_tamper_load_tampers(array('id' => $tamper['id']))) {
     drupal_write_record('capx_tamper', $tamper, 'id');
   }
   else {
     drupal_write_record('capx_tamper', $tamper);
   }
-  capx_tamper_invalidate_etags($tamper->mapper);
+  capx_tamper_invalidate_etags($tamper['mapper']);
+  return TRUE;
 }
 
 /**

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -55,6 +55,7 @@ function capx_tamper_menu() {
     'access arguments' => array('administer capx'),
     'type' => MENU_CALLBACK,
   );
+
   return $items;
 }
 

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -7,6 +7,7 @@
 
 use \CAPx\Drupal\Util\CAPx;
 use \CAPx\Drupal\Entities\CFEntity;
+use \CAPx\Drupal\Mapper\EntityMapper;
 
 define('CAPX_TAMPER', 'admin/config/capx/mapper');
 
@@ -105,15 +106,16 @@ function capx_tamper_mapper_load($mapper_id) {
  */
 function capx_tamper_get_mapper_sources(CFEntity $mapper) {
   $sources = array();
+  foreach ($mapper->properties as $property => $path) {
+    $sources[$path][] = $property;
+  }
+
   foreach ($mapper->fields as $field_key => $field_settings) {
     $field_settings = array_filter($field_settings);
     if ($field_settings) {
       $path = $field_settings[key($field_settings)];
       $sources[$path][] = $field_key;
     }
-  }
-  foreach ($mapper->properties as $property => $path) {
-    $sources[$path][] = $property;
   }
   return $sources;
 }
@@ -237,7 +239,7 @@ function capx_tamper_invalidate_etags($mapper_id) {
 /**
  * Implements hook_capx_pre_update_entity_alter().
  */
-function capx_tamper_capx_pre_update_entity_alter(&$entity, &$data, CFEntity &$mapper) {
+function capx_tamper_capx_pre_update_entity_alter(&$entity, &$data, EntityMapper &$mapper) {
   $values = array(
     'data' => $data,
     'mapper' => $mapper,
@@ -252,7 +254,7 @@ function capx_tamper_capx_pre_update_entity_alter(&$entity, &$data, CFEntity &$m
  * Change the entries in the $values['data'] according to the tamper plugins.
  */
 function capx_tamper_capx_pre_entity_create_alter(&$values) {
-  /** @var \CAPx\Drupal\Mapper\EntityMapper $mapper */
+  /** @var EntityMapper $mapper */
   $mapper = NULL;
   $data = array();
   extract($values);
@@ -265,12 +267,19 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   foreach (capx_tamper_get_mapper_sources($cfe_mapper) as $path => $targets) {
     $item = $mapper->getRemoteDataByJsonPath($data, $path);
     if (strpos($path, '*') !== FALSE) {
-      if (isset($items[0][$path][$mapper->getIndex()])) {
-        $items[0][$path] = $items[0][$path][$mapper->getIndex()];
+      $index = $mapper->getIndex();
+      if (isset($item[$index])) {
+        $item = $item[$index];
       }
     }
-    if (is_array($item) && count($item)) {
-      $item = reset($item);
+
+    if (is_array($item)) {
+      if (array_filter($item)) {
+        $item = reset($item);
+      }
+      else {
+        $item = NULL;
+      }
     }
     $items[0][$path] = $item;
   }
@@ -285,7 +294,7 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
     $plugin = feeds_tamper_get_plugin($tamper->plugin_id);
     if (function_exists($plugin['callback']) && isset($result->items[0][$tamper->source])) {
       $path = $tamper->source;
-      $field = $result->items[0][$path];
+      $field = &$result->items[0][$path];
 
       // Call any functions that have to alter the tamper before using
       // the feeds tamper plugin directly.
@@ -300,7 +309,6 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
       capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
     }
   }
-
   $values['data'] = $data;
 }
 
@@ -361,7 +369,7 @@ function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
   }
 
   if (isset($data[$piece])) {
-    capx_tamper_set_data_by_json_path($data[$piece], implode('.', $paths), $value);
+    capx_tamper_set_data_by_json_path($data[$piece], implode('.', $paths), $value, $index);
   }
 }
 

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -16,6 +16,18 @@ function capx_tamper_ctools_plugin_api($owner, $api) {
 }
 
 /**
+ * Implements hook_theme().
+ */
+function capx_tamper_theme($existing, $type, $theme, $path) {
+  return array(
+    'capx_tamper_list_form' => array(
+      'render element' => 'form',
+      'file' => 'capx_tamper.theme.inc',
+    ),
+  );
+}
+
+/**
  * Implements hook_menu().
  */
 function capx_tamper_menu() {
@@ -23,8 +35,8 @@ function capx_tamper_menu() {
 
   $items[CAPX_TAMPER . '/%capx_tamper_mapper/tamper'] = array(
     'title' => 'Tampers',
-    'page callback' => 'capx_tamper_list',
-    'page arguments' => array(4),
+    'page callback' => 'capx_tamper_build_form',
+    'page arguments' => array('list', 4),
     'file' => 'capx_tamper.forms.inc',
     'access arguments' => array('administer capx'),
     'type' => MENU_NORMAL_ITEM,
@@ -150,9 +162,17 @@ function capx_tamper_entity_update($entity, $type) {
 function capx_tamper_load_tampers($conditions = array()) {
   ctools_include('export');
   if ($conditions) {
-    return ctools_export_load_object('capx_tamper', 'conditions', $conditions);
+    $items = ctools_export_load_object('capx_tamper', 'conditions', $conditions);
   }
-  return ctools_export_load_object('capx_tamper');
+  else {
+    $items = ctools_export_load_object('capx_tamper');
+  }
+
+  usort($items, function ($a, $b) {
+    return $a->weight - $b->weight;
+  });
+
+  return $items;
 }
 
 /**
@@ -362,4 +382,18 @@ function capx_tamper_form_stanford_capx_mapper_form_alter(&$form, &$form_state, 
   $form['tampers']['cta'] = array(
     '#markup' => $cta,
   );
+}
+
+/**
+ * Creates an HTML id/class attribute name.
+ *
+ * @param string $path
+ *   JSON path.
+ *
+ * @return string
+ *   HTML ready id/class converted from the path.
+ */
+function capx_tamper_table_id($path) {
+  $path = trim($path, '$.');
+  return preg_replace("/[^A-Za-z0-9 ]/", '-', $path);
 }

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -94,24 +94,6 @@ function capx_tamper_menu() {
 }
 
 /**
- * Loader for menu & pages.
- *
- * @param string $mapper_id
- *   Machine name of the Capx Mapper.
- *
- * @return \CAPx\Drupal\Entities\CFEntity
- *   CAPx Mapper.
- */
-function capx_tamper_mapper_load($mapper_id) {
-  $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
-//  if (!$mapper) {
-//    drupal_not_found();
-//    drupal_exit();
-//  }
-  return $mapper;
-}
-
-/**
  * Takes the configurations of the CAPx Mapper and gives the available sources.
  *
  * @param CFEntity $mapper
@@ -247,7 +229,7 @@ function capx_tamper_save_instance($tamper) {
 
   // Validity check.
   list($mapper_id) = explode('-', $tamper['id']);
-  if ($mapper_id != $tamper['mapper'] || !capx_tamper_mapper_load($mapper_id)) {
+  if ($mapper_id != $tamper['mapper'] || !capx_cfe_load_by_machine_name($mapper_id, 'mapper')) {
     drupal_set_message(t('Invalid CAPx Mapper "%mapper" in tamper plugin "%description"', array(
       '%mapper' => $mapper_id,
       '%description' => $tamper['description'],
@@ -291,7 +273,7 @@ function capx_tamper_delete_instance($tamper) {
  */
 function capx_tamper_invalidate_etags($mapper_id) {
   /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
-  $mapper = capx_tamper_mapper_load($mapper_id);
+  $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
   CAPx::invalidateEtags('mapper', $mapper);
 }
 
@@ -400,7 +382,6 @@ function capx_tamper_alter_data($entity, &$data, $field_name) {
   $mapper = $e->capxMapper;
   /** @var CFEntity $cfe_mapper */
   $cfe_mapper = $mapper->getMapper();
-
 
   // Sets an object to be used for particular tamper plugins.
   // @see feeds_tamper_copy_callback().

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -59,6 +59,15 @@ function capx_tamper_menu() {
   return $items;
 }
 
+/**
+ * Loader for menu & pages.
+ *
+ * @param string $mapper_id
+ *   Machine name of the Capx Mapper.
+ *
+ * @return \CAPx\Drupal\Entities\CFEntity
+ *   CAPx Mapper.
+ */
 function capx_tamper_mapper_load($mapper_id) {
   $mapper = capx_cfe_load_by_machine_name($mapper_id, 'mapper');
   if (!$mapper) {
@@ -68,6 +77,15 @@ function capx_tamper_mapper_load($mapper_id) {
   return $mapper;
 }
 
+/**
+ * Takes the configurations of the CAPx Mapper and gives the available sources.
+ *
+ * @param \CAPx\Drupal\Entities\CFEntity $mapper
+ *   CAPx Mapper to collect available sources.
+ *
+ * @return array
+ *   Associative array of keys as json paths. Values as an array of targets.
+ */
 function capx_tamper_get_mapper_sources($mapper) {
   $sources = array();
   foreach ($mapper->fields as $field_key => $field_settings) {
@@ -87,11 +105,27 @@ function capx_tamper_get_mapper_sources($mapper) {
  * Implements hook_entity_delete().
  */
 function capx_tamper_entity_delete($entity, $type) {
-  if ($type == 'capx_cfe') {
+  if ($type == 'capx_cfe' && $entity->type == 'mapper') {
     /** @var \CAPx\Drupal\Entities\CFEntity $entity */
     db_delete('capx_tamper')
       ->condition('mapper', $entity->getMachineName())
       ->execute();
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function capx_tamper_entity_update($entity, $type) {
+  if ($type == 'capx_cfe' && $entity->type == 'mapper') {
+    /** @var \CAPx\Drupal\Entities\CFEntity $entity */
+    $sources = capx_tamper_get_mapper_sources($entity);
+    $tampers = capx_tamper_load_tampers(array('mapper' => $entity->getMachineName()));
+    foreach ($tampers as $id => $tamper) {
+      if (!isset($sources[$tamper->source])) {
+        capx_tamper_delete_instance($tamper);
+      }
+    }
   }
 }
 
@@ -139,6 +173,7 @@ function capx_tamper_save_instance($tamper) {
 function capx_tamper_delete_instance($tamper) {
   db_delete('capx_tamper')
     ->condition('id', $tamper->id)
+    ->condition('mapper', $tamper->mapper)
     ->execute();
 }
 
@@ -156,10 +191,15 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   $result = new stdClass();
   $items = array();
   foreach (capx_tamper_get_mapper_sources($cfe_mapper) as $path => $targets) {
-    $items[0][$path] = $mapper->getRemoteDataByJsonPath($data, $path);
-    if (strpos($path, '*') !== FALSE) {
+    $item = $mapper->getRemoteDataByJsonPath($data, $path);
+    if (strpos($path, '*') !== FALSE && isset($items[0][$path][$mapper->getIndex()])) {
       $items[0][$path] = $items[0][$path][$mapper->getIndex()];
     }
+    if (is_array($item) && count($item)) {
+      $item = reset($item);
+    }
+
+    $items[0][$path] = $item;
   }
   $result->items = $items;
 
@@ -182,7 +222,15 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
       }
 
       if ($field) {
-        $plugin['callback']($result, 0, $path, $field, $tamper->settings, $tamper->source);
+
+        $pre_callback = 'capx_tamper_' . $plugin['callback'];
+        $key = 0;
+        if (function_exists($pre_callback)) {
+          $pre_callback($result, $key, $path, $field, $tamper->settings, $tamper->source);
+        }
+
+
+        $plugin['callback']($result, $key, $path, $field, $tamper->settings, $tamper->source);
         capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
       }
     }
@@ -192,7 +240,34 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
 }
 
 /**
- * Given the object's data array, change a single value.
+ * Special handler for "Copy To" tamper.
+ *
+ * Switches it to a "Copy From" and flips the sources.
+ *
+ * @param object $result
+ *   Results object with items property.
+ * @param int $item_key
+ *   Index of the item. Normally 0.
+ * @param string $path
+ *   JSON path string.
+ * @param mixed $field
+ *   String for most field results to manipulate.
+ * @param array $settings
+ *   CAPx Tamper settings.
+ * @param string $source
+ *   Original source.
+ */
+function capx_tamper_feeds_tamper_copy_callback(&$result, &$item_key, &$path, &$field, &$settings, &$source) {
+  if ($settings['to_from'] == 'to') {
+    $settings['to_from'] = 'from';
+    $a = $path;
+    $path = $settings['source'];
+    $settings['source'] = $a;
+  }
+}
+
+/**
+ * Recursive function, given the object's data array, change a single value.
  *
  * @param array $data
  *   Object array from json response from API.
@@ -204,15 +279,14 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
  *   For wildcard items, change the correct indexed item.
  */
 function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
-  if (!is_array($data)) {
-    if (is_array($value)) {
-      $value = reset($value);
-    }
-    $data = $value;
-    return;
-  }
-
   $paths = explode('.', $path);
+  // End of path.
+  if (count($paths) == 1) {
+    if (isset($data[$path])) {
+      $data[$path] = $value;
+      return;
+    }
+  }
   $piece = array_shift($paths);
 
   // Beginning of the JSON path.
@@ -225,7 +299,9 @@ function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
     $piece = $index;
   }
 
-  capx_tamper_set_data_by_json_path($data[$piece], implode('.', $paths), $value);
+  if (isset($data[$piece])) {
+    capx_tamper_set_data_by_json_path($data[$piece], implode('.', $paths), $value);
+  }
 }
 
 /**

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -5,6 +5,8 @@
  * CAPx Tamper Module.
  */
 
+include_once 'views/capx_tamper.views_default_alter.inc';
+
 use \CAPx\Drupal\Util\CAPx;
 use \CAPx\Drupal\Entities\CFEntity;
 use \CAPx\Drupal\Mapper\EntityMapper;
@@ -28,6 +30,20 @@ function capx_tamper_theme($existing, $type, $theme, $path) {
     'capx_tamper_list_form' => array(
       'render element' => 'form',
       'file' => 'capx_tamper.theme.inc',
+    ),
+  );
+}
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function capx_tamper_views_data_alter(&$data) {
+  // Tampers link.
+  $data['capx_cfe']['tamper_link'] = array(
+    'title' => t('Manage Tampers link'),
+    'help' => t('Manage Tampers link for mappings'),
+    'field' => array(
+      'handler' => 'views_handler_tamper_link',
     ),
   );
 }
@@ -137,12 +153,11 @@ function capx_tamper_entity_load($entities, $type) {
  * Implements hook_entity_insert().
  */
 function capx_tamper_entity_insert($entity, $type) {
-  if ($type == 'capx_cfe' && $entity->type == 'mapper') {
-    if (isset($entity->tampers) && $entity->tampers) {
-      foreach ($entity->tampers as $tamper) {
-        capx_tamper_save_instance($tamper);
-      }
+  if ($type == 'capx_cfe' && $entity->type == 'mapper' && isset($entity->tampers)) {
+    foreach ($entity->tampers as $tamper) {
+      capx_tamper_save_instance($tamper);
     }
+
   }
 }
 
@@ -153,7 +168,7 @@ function capx_tamper_entity_insert($entity, $type) {
  * plugins that are attached.
  */
 function capx_tamper_entity_update($entity, $type) {
-  if ($type == 'capx_cfe' && $entity->type == 'mapper') {
+  if ($type == 'capx_cfe' && $entity->type == 'mapper' && isset($entity->tampers)) {
     /** @var \CAPx\Drupal\Entities\CFEntity $entity */
     $sources = capx_tamper_get_mapper_sources($entity);
     foreach ($entity->tampers as $id => $tamper) {
@@ -170,7 +185,7 @@ function capx_tamper_entity_update($entity, $type) {
  * Deletes any CAPx Tamper plugins when the mapper is deleted.
  */
 function capx_tamper_entity_delete($entity, $type) {
-  if ($type == 'capx_cfe' && $entity->type == 'mapper') {
+  if ($type == 'capx_cfe' && $entity->type == 'mapper' && isset($entity->tampers)) {
     /** @var \CAPx\Drupal\Entities\CFEntity $entity */
     foreach ($entity->tampers as $tamper) {
       capx_tamper_delete_instance($tamper);
@@ -431,7 +446,7 @@ function capx_tamper_form_stanford_capx_mapper_form_alter(&$form, &$form_state, 
   );
 
   $cta = "<br/><p>";
-  $cta .= l(t('Manage Tampers'), CAPX_TAMPER . "/$mapper_name/tamper", array("attributes" => array("class" => 'button')));
+  $cta .= l(t('Manage "!name" Tampers', array('!name' => $form_state['build_info']['args'][0]->title)), CAPX_TAMPER . "/$mapper_name/tamper", array("attributes" => array("class" => 'button')));
   $cta .= "</p>";
   $cta .= "<span><em>" . t("Clicking this button will navigate you away to a new page. Please save your work first.") . "</em></span>";
 

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -7,6 +7,15 @@
 define('CAPX_TAMPER', 'admin/config/capx/mapper/edit');
 
 /**
+ * Implements hook_ctools_plugin_api().
+ */
+function capx_tamper_ctools_plugin_api($owner, $api) {
+  if ($owner == 'mymodule' && $api == 'capx_tamper') {
+    return array('version' => 1);
+  }
+}
+
+/**
  * Implements hook_menu().
  */
 function capx_tamper_menu() {
@@ -49,23 +58,46 @@ function capx_tamper_menu() {
   return $items;
 }
 
-
-function capx_tamper_load_tamper($id) {
-  $query = db_select('capx_tamper', 'c')
-    ->fields('c')
-    ->condition('id', $id)
-    ->execute()
-    ->fetchAssoc();
-  if ($query) {
-    $query['settings'] = unserialize($query['settings']);
-    return $query;
+/**
+ * Implements hook_entity_delete().
+ */
+function capx_tamper_entity_delete($entity, $type) {
+  if ($type == 'capx_cfe') {
+    /** @var \CAPx\Drupal\Entities\CFEntity $entity */
+    db_delete('capx_tamper')
+      ->condition('mapper', $entity->getMachineName())
+      ->execute();
   }
-  return FALSE;
 }
 
+/**
+ * Load a single or all capx tamper plugins.
+ *
+ * @param array $conditions
+ *   Keyed conditions of the tampers to load.
+ *   'mapper' => mapper machine name.
+ *   'id' => tamper id.
+ *   'source' => field name or entity property.
+ *
+ * @return array
+ *   Single or all tampers configured.
+ */
+function capx_tamper_load_tampers($conditions = array()) {
+  ctools_include('export');
+  if ($conditions) {
+    return ctools_export_load_object('capx_tamper', 'conditions', $conditions);
+  }
+  return ctools_export_load_object('capx_tamper');
+}
 
+/**
+ * Saves the tamper plugin and settings.
+ *
+ * @param object $tamper
+ *   CAPx Tamper object.
+ */
 function capx_tamper_save_instance($tamper) {
-  if (capx_tamper_load_tamper($tamper['id'])) {
+  if (capx_tamper_load_tampers(array('id' => $tamper->id))) {
     drupal_write_record('capx_tamper', $tamper, 'id');
   }
   else {
@@ -73,37 +105,16 @@ function capx_tamper_save_instance($tamper) {
   }
 }
 
+/**
+ * Deletes the given CAPx Tamper plugin.
+ *
+ * @param object $tamper
+ *   CAPx Tamper plugin to delete.
+ */
 function capx_tamper_delete_instance($tamper) {
   db_delete('capx_tamper')
-    ->condition('id', $tamper['id'])
+    ->condition('id', $tamper->id)
     ->execute();
-}
-
-/**
- * @param string $mapper_id
- *   Machine name of the mapper.
- * @param null|string $source
- *   The field name/property if desired to get that particular set of tampers.
- *
- * @return array
- *   All active tampers for the given parameters.
- */
-function capx_tamper_get_tampers($mapper_id, $source = NULL) {
-  $tampers = array();
-  $query = db_select('capx_tamper', 'c');
-  $query->fields('c');
-  $query->condition('mapper', $mapper_id);;
-  if ($source) {
-    $query->condition('source', $source);
-  }
-  $query->orderBy('weight', 'ASC');
-  $results = $query->execute();
-
-  while ($row = $results->fetchAssoc()) {
-    $row['settings'] = unserialize($row['settings']);
-    $tampers[$row['weight']] = $row;
-  }
-  return $tampers;
 }
 
 /**
@@ -117,20 +128,18 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   /** @var \CAPx\Drupal\Entities\CFEntity $cfe_mapper */
   $cfe_mapper = $mapper->getMapper();
 
-  $tampers = capx_tamper_get_tampers($cfe_mapper->machine_name);
-
-  foreach ($tampers as $tamper) {
+  foreach (capx_tamper_load_tampers(array('mapper' => $cfe_mapper->machine_name)) as $tamper) {
     $path = NULL;
     $plugin = feeds_tamper_get_plugin($tamper['plugin_id']);
     if (function_exists($plugin['callback'])) {
 
-      if (isset($cfe_mapper->fields[$tamper['source']])) {
-        $temp = array_filter($cfe_mapper->fields[$tamper['source']]);
+      if (isset($cfe_mapper->fields[$tamper->source])) {
+        $temp = array_filter($cfe_mapper->fields[$tamper->source]);
         $path = $temp[key($temp)];
       }
       else {
-        if (isset($cfe_mapper->properties[$tamper['source']])) {
-          $path = $cfe_mapper->properties[$tamper['source']];
+        if (isset($cfe_mapper->properties[$tamper->source])) {
+          $path = $cfe_mapper->properties[$tamper->source];
         }
       }
 
@@ -149,7 +158,7 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
         }
 
         if ($field) {
-          $plugin['callback'](NULL, NULL, NULL, $field, $tamper['settings'], $tamper['source']);
+          $plugin['callback'](NULL, NULL, NULL, $field, $tamper->settings, $tamper->source);
           capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
         }
       }
@@ -159,6 +168,18 @@ function capx_tamper_capx_pre_entity_create_alter(&$values) {
   $values['data'] = $data;
 }
 
+/**
+ * Given the object's data array, change a single value.
+ *
+ * @param array $data
+ *   Object array from json response from API.
+ * @param string $path
+ *   JSON string path to desired value.
+ * @param mixed $value
+ *   New value to set.
+ * @param int $index
+ *   For wildcard items, change the correct indexed item.
+ */
 function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
   if (!is_array($data)) {
     $data = $value;

--- a/modules/capx_tamper/capx_tamper.theme.inc
+++ b/modules/capx_tamper/capx_tamper.theme.inc
@@ -32,7 +32,6 @@ function theme_capx_tamper_list_form($vars) {
   $header = array(
     t('Description'),
     t('Plugin'),
-    t('Status'),
     t('Operations'),
     t('Weight'),
     t('Enabled'),
@@ -48,7 +47,6 @@ function theme_capx_tamper_list_form($vars) {
         'data' => array(
           drupal_render($form['tampers'][$path][$tamper_id]['description']),
           drupal_render($form['tampers'][$path][$tamper_id]['plugin_id']),
-          drupal_render($form['tampers'][$path][$tamper_id]['status']),
           drupal_render($form['tampers'][$path][$tamper_id]['operations']),
           drupal_render($form['tampers'][$path][$tamper_id]['weight']),
           drupal_render($form['tampers'][$path][$tamper_id]['enabled']),

--- a/modules/capx_tamper/capx_tamper.theme.inc
+++ b/modules/capx_tamper/capx_tamper.theme.inc
@@ -38,7 +38,7 @@ function theme_capx_tamper_list_form($vars) {
     t('Enabled'),
   );
 
-  $output = drupal_render($form['goback']);
+  $output = drupal_render($form['mapper']);
 
   foreach (element_children($form['tampers']) as $path) {
     $paths[] = $path;

--- a/modules/capx_tamper/capx_tamper.theme.inc
+++ b/modules/capx_tamper/capx_tamper.theme.inc
@@ -17,18 +17,6 @@
 function theme_capx_tamper_list_form($vars) {
   $form = $vars['form'];
 
-  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
-  $mapper = capx_tamper_mapper_load($form['mapper']['#value']);
-  $sources = capx_tamper_get_mapper_sources($mapper);
-  foreach ($sources as &$targets) {
-    foreach ($targets as &$field_name) {
-      $instance = field_info_instance($mapper->entity_type, $field_name, $mapper->bundle_type);
-      if ($instance) {
-        $field_name = $instance['label'];
-      }
-    }
-  }
-
   $header = array(
     t('Description'),
     t('Plugin'),
@@ -39,19 +27,23 @@ function theme_capx_tamper_list_form($vars) {
 
   $output = drupal_render($form['mapper']);
 
-  foreach (element_children($form['tampers']) as $path) {
-    $paths[] = $path;
+  foreach (element_children($form['tampers']) as $target) {
+    $caption = drupal_render($form['tampers'][$target]['caption']);
     $rows = array();
-    foreach (element_children($form['tampers'][$path]) as $tamper_id) {
+
+    foreach (element_children($form['tampers'][$target]) as $tamper_id) {
+      if ($tamper_id == 'caption' || $tamper_id == 'add_link') {
+        continue;
+      }
       $rows[] = array(
         'data' => array(
-          drupal_render($form['tampers'][$path][$tamper_id]['description']),
-          drupal_render($form['tampers'][$path][$tamper_id]['plugin_id']),
-          drupal_render($form['tampers'][$path][$tamper_id]['operations']),
-          drupal_render($form['tampers'][$path][$tamper_id]['weight']),
-          drupal_render($form['tampers'][$path][$tamper_id]['enabled']),
+          drupal_render($form['tampers'][$target][$tamper_id]['description']),
+          drupal_render($form['tampers'][$target][$tamper_id]['plugin_id']),
+          drupal_render($form['tampers'][$target][$tamper_id]['operations']),
+          drupal_render($form['tampers'][$target][$tamper_id]['weight']),
+          drupal_render($form['tampers'][$target][$tamper_id]['enabled']),
         ),
-        'class' => array('draggable', 'group-' . capx_tamper_table_id($path)),
+        'class' => array('draggable', 'group-' . capx_tamper_table_id($target)),
       );
     }
 
@@ -66,13 +58,9 @@ function theme_capx_tamper_list_form($vars) {
       );
     }
 
-    // Add Plugin Link.
-    $add_link = l(t('Add Plugin'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/add/" . bin2hex($path));
-    // Put action-link class on for fanciness sake.
-    $add = '<ul class="feeds-tamper-add action-links"><li>' . $add_link . '</li></ul>';
-    // "Add plugin" link is the last row.
+    $add_link = drupal_render($form['tampers'][$target]['add_link']);
     $rows[] = array(
-      'data' => array(array('data' => $add, 'colspan' => count($header))),
+      'data' => array(array('data' => $add_link, 'colspan' => count($header))),
       'class' => array('capx-tamper-add'),
     );
 
@@ -80,22 +68,15 @@ function theme_capx_tamper_list_form($vars) {
       'header' => $header,
       'rows' => $rows,
       'attributes' => array(
-        'id' => capx_tamper_table_id($path),
+        'id' => capx_tamper_table_id($target),
         'class' => array('feeds-tamper-table'),
       ),
-      'caption' => t('!from -> !to', array(
-        '!from' => $path,
-        '!to' => implode(', ', $sources[$path]),
-      )),
+      'caption' => $caption,
     ));
+
+    drupal_add_tabledrag(capx_tamper_table_id($target), 'order', 'sibling', capx_tamper_table_id($target) . '-weight');
   }
 
   $output .= drupal_render_children($form);
-
-  foreach ($sources as $path => $targets) {
-    $table_id = capx_tamper_table_id($path);
-    drupal_add_tabledrag($table_id, 'order', 'sibling', capx_tamper_table_id($path) . '-weight');
-  }
-
   return $output;
 }

--- a/modules/capx_tamper/capx_tamper.theme.inc
+++ b/modules/capx_tamper/capx_tamper.theme.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * CAPx Tamper Theme functions.
@@ -9,6 +10,9 @@
  *
  * @param array $vars
  *   Variables.
+ *
+ * @return string
+ *   Themed output.
  */
 function theme_capx_tamper_list_form($vars) {
   $form = $vars['form'];
@@ -31,6 +35,7 @@ function theme_capx_tamper_list_form($vars) {
     t('Status'),
     t('Operations'),
     t('Weight'),
+    t('Enabled'),
   );
 
   $output = drupal_render($form['goback']);
@@ -46,6 +51,7 @@ function theme_capx_tamper_list_form($vars) {
           drupal_render($form['tampers'][$path][$tamper_id]['status']),
           drupal_render($form['tampers'][$path][$tamper_id]['operations']),
           drupal_render($form['tampers'][$path][$tamper_id]['weight']),
+          drupal_render($form['tampers'][$path][$tamper_id]['enabled']),
         ),
         'class' => array('draggable', 'group-' . capx_tamper_table_id($path)),
       );
@@ -63,19 +69,22 @@ function theme_capx_tamper_list_form($vars) {
     }
 
     // Add Plugin Link.
-    $add_link =  l(t('Add Plugin'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/add/" . bin2hex($path));
+    $add_link = l(t('Add Plugin'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/add/" . bin2hex($path));
     // Put action-link class on for fanciness sake.
     $add = '<ul class="feeds-tamper-add action-links"><li>' . $add_link . '</li></ul>';
     // "Add plugin" link is the last row.
     $rows[] = array(
-      'data' => array(array('data' => $add, 'colspan' => 5)),
-      'class' => array('feeds-tamper-add'),
+      'data' => array(array('data' => $add, 'colspan' => count($header))),
+      'class' => array('capx-tamper-add'),
     );
 
     $output .= theme('table', array(
       'header' => $header,
       'rows' => $rows,
-      'attributes' => array('id' => capx_tamper_table_id($path)),
+      'attributes' => array(
+        'id' => capx_tamper_table_id($path),
+        'class' => array('feeds-tamper-table'),
+      ),
       'caption' => t('!from -> !to', array(
         '!from' => $path,
         '!to' => implode(', ', $sources[$path]),
@@ -92,5 +101,3 @@ function theme_capx_tamper_list_form($vars) {
 
   return $output;
 }
-
-

--- a/modules/capx_tamper/capx_tamper.theme.inc
+++ b/modules/capx_tamper/capx_tamper.theme.inc
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @file
+ * CAPx Tamper Theme functions.
+ */
+
+/**
+ * Process sortable table.
+ *
+ * @param array $vars
+ *   Variables.
+ */
+function theme_capx_tamper_list_form($vars) {
+  $form = $vars['form'];
+
+  /** @var \CAPx\Drupal\Entities\CFEntity $mapper */
+  $mapper = capx_tamper_mapper_load($form['mapper']['#value']);
+  $sources = capx_tamper_get_mapper_sources($mapper);
+  foreach ($sources as &$targets) {
+    foreach ($targets as &$field_name) {
+      $instance = field_info_instance($mapper->entity_type, $field_name, $mapper->bundle_type);
+      if ($instance) {
+        $field_name = $instance['label'];
+      }
+    }
+  }
+
+  $header = array(
+    t('Description'),
+    t('Plugin'),
+    t('Status'),
+    t('Operations'),
+    t('Weight'),
+  );
+
+  $output = drupal_render($form['goback']);
+
+  foreach (element_children($form['tampers']) as $path) {
+    $paths[] = $path;
+    $rows = array();
+    foreach (element_children($form['tampers'][$path]) as $tamper_id) {
+      $rows[] = array(
+        'data' => array(
+          drupal_render($form['tampers'][$path][$tamper_id]['description']),
+          drupal_render($form['tampers'][$path][$tamper_id]['plugin_id']),
+          drupal_render($form['tampers'][$path][$tamper_id]['status']),
+          drupal_render($form['tampers'][$path][$tamper_id]['operations']),
+          drupal_render($form['tampers'][$path][$tamper_id]['weight']),
+        ),
+        'class' => array('draggable', 'group-' . capx_tamper_table_id($path)),
+      );
+    }
+
+    // Empty plugins.
+    if (!$rows) {
+      $rows[] = array(
+        array(
+          'data' => t('No plugins defined.'),
+          'colspan' => count($header),
+          'class' => array('add-tamper'),
+        ),
+      );
+    }
+
+    // Add Plugin Link.
+    $add_link =  l(t('Add Plugin'), CAPX_TAMPER . "/{$mapper->getMachineName()}/tamper/add/" . bin2hex($path));
+    // Put action-link class on for fanciness sake.
+    $add = '<ul class="feeds-tamper-add action-links"><li>' . $add_link . '</li></ul>';
+    // "Add plugin" link is the last row.
+    $rows[] = array(
+      'data' => array(array('data' => $add, 'colspan' => 5)),
+      'class' => array('feeds-tamper-add'),
+    );
+
+    $output .= theme('table', array(
+      'header' => $header,
+      'rows' => $rows,
+      'attributes' => array('id' => capx_tamper_table_id($path)),
+      'caption' => t('!from -> !to', array(
+        '!from' => $path,
+        '!to' => implode(', ', $sources[$path]),
+      )),
+    ));
+  }
+
+  $output .= drupal_render_children($form);
+
+  foreach ($sources as $path => $targets) {
+    $table_id = capx_tamper_table_id($path);
+    drupal_add_tabledrag($table_id, 'order', 'sibling', capx_tamper_table_id($path) . '-weight');
+  }
+
+  return $output;
+}
+
+

--- a/modules/capx_tamper/css/capx_tamper.css
+++ b/modules/capx_tamper/css/capx_tamper.css
@@ -1,0 +1,58 @@
+/* Stolen from Rules */
+.feeds-tamper-table ul.action-links {
+  margin: 0;
+  padding: 0;
+}
+
+.feeds-tamper-table li {
+  list-style-position: inside;
+}
+
+.feeds-tamper-table ul.feeds-tamper-add a {
+  line-height: 1em;
+}
+
+tr.feeds-tamper-add td {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+
+.feeds-tamper-table {
+  margin-top: 3em;
+  position: relative;
+}
+
+/* Fix table drag weights to don't take extra space */
+.feeds-tamper-table .tabledrag-toggle-weight-wrapper {
+  float: right;
+  position: absolute;
+  right: 0px;
+}
+
+.feeds-tamper-table caption {
+  font-size: 110%;
+  font-weight: bold;
+  padding-bottom: 0.5em;
+  text-align: left;
+}
+
+.feeds-tamper-table tr.disabled td {
+  color: #aaaaaa;
+}
+
+.feeds-tamper-table tr.disabled {
+  color: #aaaaaa;
+  background-color: #f5f5f5;
+}
+
+/* Style add plugin form. */
+
+/* hide the next button when not degrading to non-javascript browser */
+html.js .no-js {
+  display: none;
+}
+
+/* Make Choose button come up next to select. */
+.form-item-plugin-id {
+  display: inline-block;
+}

--- a/modules/capx_tamper/views/capx_tamper.views_default_alter.inc
+++ b/modules/capx_tamper/views/capx_tamper.views_default_alter.inc
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Views Default Alters.
+ */
+
+/**
+ * Implements hook_views_default_views_alter().
+ */
+function capx_tamper_views_default_views_alter(&$views) {
+  if (isset($views['capx_mappers'])) {
+    $handler = &$views['capx_mappers']->display['default']->handler;
+
+    /* Field: Configuration Entity: Manage Tampers link */
+    $handler->display->display_options['fields']['tamper_link']['id'] = 'tamper_link';
+    $handler->display->display_options['fields']['tamper_link']['table'] = 'capx_cfe';
+    $handler->display->display_options['fields']['tamper_link']['field'] = 'tamper_link';
+    $handler->display->display_options['fields']['tamper_link']['label'] = '';
+    $handler->display->display_options['fields']['tamper_link']['exclude'] = TRUE;
+    $handler->display->display_options['fields']['tamper_link']['element_label_colon'] = FALSE;
+    $handler->display->display_options['fields']['tamper_link']['text'] = 'Tampers';
+    /* Field: Global: Custom text */
+
+    $action_links = $handler->display->display_options['fields']['nothing_2'];
+    unset($handler->display->display_options['fields']['nothing_2']);
+    $action_links['alter']['text'] = trim($action_links['alter']['text']);
+    $action_links['alter']['text'] .= ' | [tamper_link]';
+
+    $handler->display->display_options['fields']['nothing_2'] = $action_links;
+  }
+}

--- a/modules/capx_tamper/views/capx_tamper.views_default_alter.inc
+++ b/modules/capx_tamper/views/capx_tamper.views_default_alter.inc
@@ -9,24 +9,28 @@
  * Implements hook_views_default_views_alter().
  */
 function capx_tamper_views_default_views_alter(&$views) {
-  if (isset($views['capx_mappers'])) {
-    $handler = &$views['capx_mappers']->display['default']->handler;
 
-    /* Field: Configuration Entity: Manage Tampers link */
-    $handler->display->display_options['fields']['tamper_link']['id'] = 'tamper_link';
-    $handler->display->display_options['fields']['tamper_link']['table'] = 'capx_cfe';
-    $handler->display->display_options['fields']['tamper_link']['field'] = 'tamper_link';
-    $handler->display->display_options['fields']['tamper_link']['label'] = '';
-    $handler->display->display_options['fields']['tamper_link']['exclude'] = TRUE;
-    $handler->display->display_options['fields']['tamper_link']['element_label_colon'] = FALSE;
-    $handler->display->display_options['fields']['tamper_link']['text'] = 'Tampers';
-    /* Field: Global: Custom text */
-
-    $action_links = $handler->display->display_options['fields']['nothing_2'];
-    unset($handler->display->display_options['fields']['nothing_2']);
-    $action_links['alter']['text'] = trim($action_links['alter']['text']);
-    $action_links['alter']['text'] .= ' | [tamper_link]';
-
-    $handler->display->display_options['fields']['nothing_2'] = $action_links;
+  if (!isset($views['capx_mappers'])) {
+    return;
   }
+
+  // Add a tamper link to the mappers list view.
+  $handler = &$views['capx_mappers']->display['default']->handler;
+
+  /* Field: Configuration Entity: Manage Tampers link */
+  $handler->display->display_options['fields']['tamper_link']['id'] = 'tamper_link';
+  $handler->display->display_options['fields']['tamper_link']['table'] = 'capx_cfe';
+  $handler->display->display_options['fields']['tamper_link']['field'] = 'tamper_link';
+  $handler->display->display_options['fields']['tamper_link']['label'] = '';
+  $handler->display->display_options['fields']['tamper_link']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['tamper_link']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['tamper_link']['text'] = 'Tampers';
+
+  /* Field: Global: Custom text */
+  $action_links = $handler->display->display_options['fields']['nothing_2'];
+  unset($handler->display->display_options['fields']['nothing_2']);
+  $action_links['alter']['text'] = trim($action_links['alter']['text']);
+  $action_links['alter']['text'] .= ' | [tamper_link]';
+
+  $handler->display->display_options['fields']['nothing_2'] = $action_links;
 }

--- a/modules/capx_tamper/views/views_handler_tamper_link.inc
+++ b/modules/capx_tamper/views/views_handler_tamper_link.inc
@@ -6,7 +6,7 @@
  */
 
 /**
- * Field handler to present a link to the node.
+ * Field handler to present a link to the tamper edit form.
  *
  * @ingroup views_field_handlers
  */
@@ -52,7 +52,7 @@ class views_handler_tamper_link extends views_handler_field_entity {
   public function render_link($mapper) {
     $this->options['alter']['make_link'] = TRUE;
     $this->options['alter']['path'] = "admin/config/capx/mapper/" . $mapper->getMachineName() . '/tamper';
-    $text = !empty($this->options['text']) ? $this->options['text'] : t('Edit');
+    $text = !empty($this->options['text']) ? $this->options['text'] : t('Tamper');
     return $text;
   }
 

--- a/modules/capx_tamper/views/views_handler_tamper_link.inc
+++ b/modules/capx_tamper/views/views_handler_tamper_link.inc
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @file
+ * Definition of views_handler_tamper_link.
+ */
+
+/**
+ * Field handler to present a link to the node.
+ *
+ * @ingroup views_field_handlers
+ */
+class views_handler_tamper_link extends views_handler_field_entity {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function option_definition() {
+    $options = parent::option_definition();
+    $options['text'] = array('default' => '', 'translatable' => TRUE);
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function options_form(&$form, &$form_state) {
+    $form['text'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Text to display'),
+      '#default_value' => $this->options['text'],
+    );
+    parent::options_form($form, $form_state);
+
+    // The path is set by render_link function so don't allow to set it.
+    $form['alter']['path'] = array('#access' => FALSE);
+    $form['alter']['external'] = array('#access' => FALSE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render($values) {
+    if ($entity = $this->get_value($values)) {
+      return $this->render_link($entity);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render_link($mapper) {
+    $this->options['alter']['make_link'] = TRUE;
+    $this->options['alter']['path'] = "admin/config/capx/mapper/" . $mapper->getMachineName() . '/tamper';
+    $text = !empty($this->options['text']) ? $this->options['text'] : t('Edit');
+    return $text;
+  }
+
+}

--- a/stanford_capx.api.php
+++ b/stanford_capx.api.php
@@ -12,7 +12,7 @@
  * @param  [type] $remote_data_paths [description]
  * @return [type]                    [description]
  */
-function hook_capx_pre_map_field_alter(&$entity, &$field_name, &$remote_data_paths) {
+function hook_capx_pre_map_field_alter(&$entity, &$field_name, &$remote_data_paths, &$data) {
 
 }
 

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -719,34 +719,3 @@ function stanford_capx_form_taxonomy_form_term_alter(&$form, &$form_state) {
     $form['actions']['delete']['#disabled'] = TRUE;
   }
 }
-
-/**
- * Add a validation function to the import form.
- */
-function capx_tamper_form_stanford_capx_preset_import_form_alter(&$form, &$form_state) {
-  $form['#validate'][] = "capx_tamper_form_stanford_capx_preset_import_form_alter_validate";
-}
-
-/**
- * Do some validation prior to saving.
- * @param [type] $form       [description]
- * @param [type] $form_state [description]
- */
-function capx_tamper_form_stanford_capx_preset_import_form_alter_validate($form, &$form_state) {
-  $code = $form_state['values']['code'];
-  $cfe = entity_import('capx_cfe', $code);
-
-  if (isset($cfe->tampers)) {
-    foreach($cfe->tampers as $tamper) {
-      // Validity check.
-      list($mapper_id) = explode('-', $tamper['id']);
-      if ($mapper_id !== $tamper['mapper'] || $mapper_id !== $cfe->machine_name) {
-        form_set_error('code', t('Invalid CAPx Mapper "%mapper" in tamper plugin "%description"', array(
-          '%mapper' => $mapper_id,
-          '%description' => $tamper['description'],
-        )));
-      }
-    }
-  }
-
-}

--- a/stanford_capx.module
+++ b/stanford_capx.module
@@ -719,3 +719,34 @@ function stanford_capx_form_taxonomy_form_term_alter(&$form, &$form_state) {
     $form['actions']['delete']['#disabled'] = TRUE;
   }
 }
+
+/**
+ * Add a validation function to the import form.
+ */
+function capx_tamper_form_stanford_capx_preset_import_form_alter(&$form, &$form_state) {
+  $form['#validate'][] = "capx_tamper_form_stanford_capx_preset_import_form_alter_validate";
+}
+
+/**
+ * Do some validation prior to saving.
+ * @param [type] $form       [description]
+ * @param [type] $form_state [description]
+ */
+function capx_tamper_form_stanford_capx_preset_import_form_alter_validate($form, &$form_state) {
+  $code = $form_state['values']['code'];
+  $cfe = entity_import('capx_cfe', $code);
+
+  if (isset($cfe->tampers)) {
+    foreach($cfe->tampers as $tamper) {
+      // Validity check.
+      list($mapper_id) = explode('-', $tamper['id']);
+      if ($mapper_id !== $tamper['mapper'] || $mapper_id !== $cfe->machine_name) {
+        form_set_error('code', t('Invalid CAPx Mapper "%mapper" in tamper plugin "%description"', array(
+          '%mapper' => $mapper_id,
+          '%description' => $tamper['description'],
+        )));
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
# To Test

1. Checkout branch capx-tamper
2. enable module capx_tamper
3. create/edit a CAPx mapper
4. near the bottom expand the 'Tampers' fieldset and click on 'Manage Tampers'
5. configure a tamper plugin similarly to feeds tamper module.
6. import content.
7. validate tampers applied.