### PR TITLE
Fixed validation when auto nodetitle is configured for the entity

### DIFF
--- a/modules/capx_auto_nodetitle/capx_auto_nodetitle.module
+++ b/modules/capx_auto_nodetitle/capx_auto_nodetitle.module
@@ -37,13 +37,12 @@ function capx_auto_nodetitle_mapper_form_alter(&$form, &$form_state) {
   // the same properties form. Instead of creating new property forms for each
   // node bundle we find lets just get rid of the required property and handle
   // the condition in the validate hook...
-
   $key = array_search("required", $form['field-mapping']['node-properties']["title"]["#attributes"]["class"]);
   if ($key !== FALSE) {
     unset($form['field-mapping']['node-properties']['title']['#attributes']['class'][$key]);
   }
-
-  $form["#validate"][] = "capx_auto_nodetitle_mapper_form_alter_validate";
+  array_unshift($form["#validate"], 'capx_auto_nodetitle_mapper_form_alter_validate');
+  array_unshift($form["#submit"], 'capx_auto_nodetitle_mapper_form_alter_submit');
 }
 
 
@@ -54,11 +53,10 @@ function capx_auto_nodetitle_mapper_form_alter(&$form, &$form_state) {
  * @param  [type] &$form_state [description]
  */
 function capx_auto_nodetitle_mapper_form_alter_validate($form, &$form_state) {
-
   $values = $form_state["values"];
   $entity_type = $values["entity-type"];
   $bundle_type = $values["bundle-node"];
-  $title = $values["field-mapping"]["node-properties"]["title"];
+  $title = &$form_state["values"]["field-mapping"]["node-properties"]["title"];
 
   // Only on nodes...
   if ($entity_type !== "node") {
@@ -80,21 +78,39 @@ function capx_auto_nodetitle_mapper_form_alter_validate($form, &$form_state) {
 
   // Ok we are on a node look up the bundle ant settings in the variable table.
   $setting = variable_get("ant_" . $bundle_type, 0);
-
   // Ant settings:
   // 0: Off
   // 1: Automatically generate the title and hide the title field.
   // 2: Automatically generate the title if the title field is left empty.
-  if ($setting == "1") {
-    // Node title is enabled. Check to see if there was a value in the title.
-    if (!empty($title)) {
-      form_set_error("field-mapping][node-properties][title", "The " . $bundle_type . " node type has an auto_nodetitle setting enabled. You cannot map a CAP value to the title property. To change the auto_nodetitle please edit the setting on the " . l(t("manage content type page"), "admin/structure/types/manage/" . $bundle_type, array("attributes" => array("target" => "_blank"))));
-    }
-  }
-  else {
-    if (empty($title)) {
-      form_set_error("field-mapping][node-properties][title", "The title node property is required");
-    }
-  }
+  // Sets a token to be replaced before save that bypasses any validation on
+  // the title field.
+  switch ($setting) {
+    case 0:
+      if (empty($title)) {
+        form_set_error("field-mapping][node-properties][title", "The title node property is required");
+      }
+      break;
 
+    case 1:
+      // Node title is enabled. Check to see if there was a value in the title.
+      if (empty($title)) {
+        $title = '[autonodetitle]';
+      }
+      else {
+        form_set_error("field-mapping][node-properties][title", "The " . $bundle_type . " node type has an auto_nodetitle setting enabled. You cannot map a CAP value to the title property. To change the auto_nodetitle please edit the setting on the " . l(t("manage content type page"), "admin/structure/types/manage/" . $bundle_type, array("attributes" => array("target" => "_blank"))));
+      }
+    case 2:
+      if (empty($title)) {
+        $title = '[autonodetitle]';
+      }
+      break;
+  }
+}
+
+/**
+ * Mapper form submit to remove the [autonodetitle] token from validation.
+ */
+function capx_auto_nodetitle_mapper_form_alter_submit($form, &$form_state) {
+  $title = &$form_state["values"]["field-mapping"]["node-properties"]["title"];
+  $title = str_replace('[autonodetitle]', '', $title);
 }

--- a/modules/capx_tamper/capx_tamper.forms.inc
+++ b/modules/capx_tamper/capx_tamper.forms.inc
@@ -55,6 +55,9 @@ function capx_tamper_list_form($form, &$form_state, CFEntity $mapper, $source = 
   $sources = capx_tamper_get_mapper_sources($mapper);
 
   foreach ($sources as $target => $path) {
+    if (!$path) {
+      continue;
+    }
     $path_tampers = capx_tamper_load_tampers(array(
       'mapper' => $mapper->getMachineName(),
       'target' => $target,


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed the validation when creating a mapper. Before with auto nodetitle configured for the node type, the title field was still required.

# Urgency
- Minor bug

# Steps to Test

1. Checkout the branch and enable capx_auto_nodetitle
2. ensure the node type is configured to use auto nodetitle
3. Create a capx mapper on that node type
4. leave the node title field empty and save.