### PR TITLE
SOENEW: Changed workgroup check array to add a trim function to reduc…

### DIFF
--- a/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
@@ -84,7 +84,7 @@ class LookupWorkgroupOrphans implements LookupInterface {
    *
    * @param array $results
    *   An array of results from the API.
-   * 
+   *
    * @return array
    *   An array keyed/valued with profileId => profileId
    */

--- a/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
@@ -82,8 +82,11 @@ class LookupWorkgroupOrphans implements LookupInterface {
   /**
    * Trims out bloat from a profile and return only the profileId in an array.
    *
-   * @param $results
+   * @param array $results
+   *   An array of results from the API.
+   * 
    * @return array
+   *   An array keyed/valued with profileId => profileId
    */
   private function trimResults($results) {
     $return = array();
@@ -96,4 +99,3 @@ class LookupWorkgroupOrphans implements LookupInterface {
   }
 
 }
-

--- a/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
+++ b/includes/CAPx/Drupal/Importer/Orphans/Lookups/LookupWorkgroupOrphans.php
@@ -50,11 +50,16 @@ class LookupWorkgroupOrphans implements LookupInterface {
     $response = $client->api('profile')->search("privGroups", $groups);
     $results = $response['values'];
 
+    // Trim out the information we don't need so that the php variable doesn't
+    // bloat and cause OOM errors.
+    $results = $this->trimResults($results);
+
     // Pull every existing page from CAPx one by one and merge to the results.
     for ($page = 2; $page <= $response['totalPages']; $page++) {
       $client->setPage($page);
       $response = $client->api('profile')->search("privGroups", $groups);
-      $results = array_merge($results, $response['values']);
+      $trimmed = $this->trimResults($response['values']);
+      $results = array_merge($results, $trimmed);
     }
 
     drupal_alter('capx_orphan_profile_results', $results);
@@ -74,4 +79,21 @@ class LookupWorkgroupOrphans implements LookupInterface {
     return $orphans;
   }
 
+  /**
+   * Trims out bloat from a profile and return only the profileId in an array.
+   *
+   * @param $results
+   * @return array
+   */
+  private function trimResults($results) {
+    $return = array();
+
+    foreach ($results as $profile) {
+      $return[$profile['profileId']] = $profile['profileId'];
+    }
+
+    return $return;
+  }
+
 }
+


### PR DESCRIPTION

# READY FOR REVIEW

# Summary
- Removes extra profile information from the storage array when doing a workgroup orphan check in order to reduce the overall memory load and potential OOM break.

# Needed By (Date)
- ASAP

# Urgency
- JSE SOE New is borkd

# Steps to Test

1. clone jse-soe-new to local
2. Check out this branch
3. Run importer check on default importer
4. Smile

# Affected Projects or Products
- engineering.stanford.edu

# Associated Issues and/or People
- @tsui1 
