### PR TITLE
Mimi

### DIFF
--- a/modules/capx_filters/capx_filters.module
+++ b/modules/capx_filters/capx_filters.module
@@ -340,7 +340,7 @@ function capx_filters_entity_presave($entity, $type) {
   if (!$_capx_filters_updated) {
 
     /* @param CFEntity $entity */
-    $orig_entity = capx_cfe_load_by_machine_name($entity->machine_name, 'importer');
+    $orig_entity = capx_cfe_load_by_machine_name($entity->getMachineName(), 'importer');
 
     if (isset($orig_entity->filters)) {
       $entity->settings['filters'] = $orig_entity->filters;

--- a/modules/capx_filters/capx_filters.module
+++ b/modules/capx_filters/capx_filters.module
@@ -330,7 +330,7 @@ function capx_filters_parse_date($string) {
 function capx_filters_entity_presave($entity, $type) {
 
   // We only want to act on importer cfe entities.
-  if ($type !== 'capx_cfe' && $entity->type !== 'importer') {
+  if ($type !== 'capx_cfe' || $entity->type !== 'importer') {
     return NULL;
   }
 

--- a/modules/capx_filters/capx_filters.module
+++ b/modules/capx_filters/capx_filters.module
@@ -340,7 +340,7 @@ function capx_filters_entity_presave($entity, $type) {
   if (!$_capx_filters_updated) {
 
     /* @param CFEntity $entity */
-    $orig_entity = capx_cfe_load_by_machine_name($entity->getMachineName(), 'importer');
+    $orig_entity = capx_cfe_load_by_machine_name($entity->machine_name, 'importer');
 
     if (isset($orig_entity->filters)) {
       $entity->settings['filters'] = $orig_entity->filters;

--- a/stanford_capx.entity.hooks.inc
+++ b/stanford_capx.entity.hooks.inc
@@ -288,7 +288,7 @@ function stanford_capx_entity_load($entities, $type) {
   // Add the capx information if it matches.
   foreach ($ids as $entity_id) {
     // If we do not find a match then carry on.
-    if (isset($meta[$type][$entity_id]) && $meta[$type][$entity_id]->entity_type == $type) {
+    if (isset($meta[$type][$entity_id]) && $meta[$type][$entity_id]->entity_type == $type && isset($entities[$entity_id])) {
       $entities[$entity_id]->capx = (array) $meta[$entity_id];
     }
   }

--- a/stanford_capx.entity.hooks.inc
+++ b/stanford_capx.entity.hooks.inc
@@ -258,7 +258,6 @@ function stanford_capx_entity_load($entities, $type) {
   // are over a value then switch from one big cached call to multiple pings of
   // the database. We are trading PHP memory for hammering the DB with multiple
   // queries.
-
   $count = db_select('capx_profiles')
     ->fields(NULL, array('id'))
     ->countQuery()

--- a/stanford_capx.entity.hooks.inc
+++ b/stanford_capx.entity.hooks.inc
@@ -245,13 +245,40 @@ function stanford_capx_entity_update($entity, $type) {
 function stanford_capx_entity_load($entities, $type) {
 
   $ids = array_keys($entities);
-  $meta = &drupal_static(__FUNCTION__, NULL);
+  $meta = &drupal_static(__FUNCTION__, array());
 
-  if (empty($meta)) {
-    $meta = db_select("capx_profiles", 'capx')
+  // Some sites have wwaaayyy too many items in the capx_profiles table for this
+  // to load with an appropriate amount of memory. You can thank Zach Chandler
+  // for finding out this edge case. As such, we will apply two different
+  // stategies for fetching the CAPx metadata. If the amount of profile entries
+  // are over a value then switch from one big cached call to multiple pings of
+  // the database. We are trading PHP memory for hammering the DB with multiple
+  // queries.
+
+  $count = db_select('capx_profiles')
+    ->fields(NULL, array('id'))
+    ->countQuery()
+    ->execute()
+    ->fetchField();
+
+  if ($count > variable_get('stanford_capx_entity_load_limit', 10000)) {
+
+    $query_results = db_select("capx_profiles", 'capx')
       ->fields('capx')
+      ->condition('entity_type', $type)
+      ->condition('entity_id', array_keys($entities))
       ->execute()
       ->fetchAllAssoc('entity_id');
+
+    $meta = $meta + $query_results;
+  }
+  else {
+    if (empty($meta)) {
+      $meta = db_select("capx_profiles", 'capx')
+        ->fields('capx')
+        ->execute()
+        ->fetchAllAssoc('entity_id');
+    }
   }
 
   // Add the capx information if it matches.

--- a/stanford_capx.entity.hooks.inc
+++ b/stanford_capx.entity.hooks.inc
@@ -247,6 +247,10 @@ function stanford_capx_entity_load($entities, $type) {
   $ids = array_keys($entities);
   $meta = &drupal_static(__FUNCTION__, array());
 
+  if (!isset($meta[$type])) {
+    $meta[$type] = array();
+  }
+
   // Some sites have wwaaayyy too many items in the capx_profiles table for this
   // to load with an appropriate amount of memory. You can thank Zach Chandler
   // for finding out this edge case. As such, we will apply two different
@@ -262,19 +266,19 @@ function stanford_capx_entity_load($entities, $type) {
     ->fetchField();
 
   if ($count > variable_get('stanford_capx_entity_load_limit', 10000)) {
-
+    $query_entities = array_diff_key($entities, $meta[$type]);
     $query_results = db_select("capx_profiles", 'capx')
       ->fields('capx')
       ->condition('entity_type', $type)
-      ->condition('entity_id', array_keys($entities))
+      ->condition('entity_id', array_keys($query_entities))
       ->execute()
       ->fetchAllAssoc('entity_id');
 
-    $meta = $meta + $query_results;
+    $meta[$type] = $meta[$type] + $query_results;
   }
   else {
-    if (empty($meta)) {
-      $meta = db_select("capx_profiles", 'capx')
+    if (empty($meta[$type])) {
+      $meta[$type] = db_select("capx_profiles", 'capx')
         ->fields('capx')
         ->execute()
         ->fetchAllAssoc('entity_id');
@@ -284,7 +288,7 @@ function stanford_capx_entity_load($entities, $type) {
   // Add the capx information if it matches.
   foreach ($ids as $entity_id) {
     // If we do not find a match then carry on.
-    if (isset($meta[$entity_id]) && $meta[$entity_id]->entity_type == $type) {
+    if (isset($meta[$type][$entity_id]) && $meta[$type][$entity_id]->entity_type == $type) {
       $entities[$entity_id]->capx = (array) $meta[$entity_id];
     }
   }

--- a/stanford_capx.entity.hooks.inc
+++ b/stanford_capx.entity.hooks.inc
@@ -289,7 +289,7 @@ function stanford_capx_entity_load($entities, $type) {
   foreach ($ids as $entity_id) {
     // If we do not find a match then carry on.
     if (isset($meta[$type][$entity_id]) && $meta[$type][$entity_id]->entity_type == $type && isset($entities[$entity_id])) {
-      $entities[$entity_id]->capx = (array) $meta[$entity_id];
+      $entities[$entity_id]->capx = (array) $meta[$type][$entity_id];
     }
   }
 


### PR DESCRIPTION

# READY FOR REVIEW

# Summary

+  // Some sites have wwaaayyy too many items in the capx_profiles table for this
+  // to load with an appropriate amount of memory. You can thank Zach Chandler
+  // for finding out this edge case. As such, we will apply two different
+  // stategies for fetching the CAPx metadata. If the amount of profile entries
+  // are over a value then switch from one big cached call to multiple pings of
+  // the database. We are trading PHP memory for hammering the DB with multiple
+  // queries.

# Needed By (Date)
- July 1st.

# Urgency
- Moderate.

# Steps to Test

1. Clone https://sites.stanford.edu/mimisbrunnr/ to local
2. Check out this branch
3. Play with threshold setting

# Affected Projects or Products
- Not really. Just Mimi.

# Associated Issues and/or People
- None.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)