### PR TITLE
Tamper Recursion bug 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ php:
   - '5.6'
 
 sudo: required
+dist: precise
 
 cache:
   directories:

--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -352,6 +352,9 @@ function capx_tamper_feeds_tamper_copy_callback(&$result, &$item_key, &$path, &$
  */
 function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
   $path = trim($path, '$.');
+  // If an index for an item is give, replace brackets with "." to allow
+  // recursion.
+  $path = str_replace('[', '.', str_replace(']', '', $path));
 
   $paths = explode('.', $path);
   $piece = array_shift($paths);
@@ -417,7 +420,6 @@ function capx_tamper_alter_data($entity, &$data, $field_name) {
   /** @var CFEntity $cfe_mapper */
   $cfe_mapper = $mapper->getMapper();
 
-
   // Sets an object to be used for particular tamper plugins.
   // @see feeds_tamper_copy_callback().
   $result = new stdClass();
@@ -445,7 +447,7 @@ function capx_tamper_alter_data($entity, &$data, $field_name) {
 
   // Loop through tamper plugins on the mapper.
   foreach ($cfe_mapper->tampers as $tamper) {
-    if ($tamper->disabled || $tamper->target !== $field_name) {
+    if ((isset($tamper->disabled) && $tamper->disabled) || $tamper->target !== $field_name) {
       continue;
     }
     $plugin = feeds_tamper_get_plugin($tamper->plugin_id);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allows tampers to work if a user puts in the index of an item: `key[2]`

# Needed By (Date)
- When you can

# Urgency
- medium

# Steps to Test

1. checkout branch
2. create capx mapper with an index like `key[1]` for any field.
3. create a tamper on that mapped field
4. run the importer
5. verify data was tampered.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)