### PR TITLE
Change file name if since the lastModified value will change

### DIFF
--- a/includes/CAPx/Drupal/Processors/FieldProcessors/FieldProcessorAbstract.php
+++ b/includes/CAPx/Drupal/Processors/FieldProcessors/FieldProcessorAbstract.php
@@ -43,7 +43,7 @@ abstract class FieldProcessorAbstract implements FieldProcessorInterface {
    * @param array $data
    *   An array of data from the CAP API.
    */
-  public function put($data) {
+  public function put(array $data) {
 
     $entity = $this->getEntity();
     $fieldName = $this->getFieldName();

--- a/includes/CAPx/Drupal/Processors/FieldProcessors/FieldProcessorInterface.php
+++ b/includes/CAPx/Drupal/Processors/FieldProcessors/FieldProcessorInterface.php
@@ -1,17 +1,20 @@
 <?php
-/**
- * @file
- * @author [author] <[email]>
- */
 
 namespace CAPx\Drupal\Processors\FieldProcessors;
 
+/**
+ * Interface FieldProcessorInterface.
+ *
+ * @package CAPx\Drupal\Processors\FieldProcessors
+ */
 interface FieldProcessorInterface {
 
   /**
    * One entry point for them all!
-   * @param  array $data Data from the CAP API.
+   *
+   * @param array $data
+   *   Data from the CAP API.
    */
-  public function put($data);
+  public function put(array $data);
 
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use the entire image array as the name generator. This includes a timestamp paramateter 'lastModified' so this will change the image name when the user changes their photo. This will eliminate the issue of image style caches.
- Cap API now contains a timestamp in the image url. `https://cap.stanford.edu/profiles/viewImage?profileId=162949&type=big&ts=1509739817173` So do we really need this change?
- Travis and behat are borked at the moment due to ajax issues and now user login errors.

# Needed By (Date)
- whenever

# Urgency
- low

# Steps to Test

1. Checkout branch
2. run cap import
3. verify images are still imported.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)