### PR TITLE
SOE-3308: Tamper wildcard index fails

### DIFF
--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -351,6 +351,8 @@ function capx_tamper_feeds_tamper_copy_callback(&$result, &$item_key, &$path, &$
  *   For wildcard items, change the correct indexed item.
  */
 function capx_tamper_set_data_by_json_path(&$data, $path, $value, $index = 0) {
+  // Sometimes index is passed as null, so lets cast it to integer all the time.
+  $index = (int) $index;
   $path = trim($path, '$.');
   // If an index for an item is given, replace brackets with "." to allow
   // recursion.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- If a selector is using a wildcard, sometimes the tamper tries to set a `null` array key. This casts the delta/index to make sure we always have a numerical value.

# Needed By (Date)
- Soon

# Urgency
- high

# Steps to Test

1. Checkout this branch. 
2. use a selector path like `$.titles.*.title` mapped to a field
3. add a simple tamper like a string replace
4. import the data
5. ensure the tamper effects occur.


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)