### PR TITLE
SOE-3326 Fix wildcard tampers

### DIFF
--- a/modules/capx_tamper/capx_tamper.module
+++ b/modules/capx_tamper/capx_tamper.module
@@ -428,20 +428,8 @@ function capx_tamper_alter_data($entity, &$data, $field_name) {
   $items = array();
   foreach (capx_tamper_get_mapper_sources($cfe_mapper) as $path) {
     $item = $mapper->getRemoteDataByJsonPath($data, $path);
-    if (strpos($path, '*') !== FALSE) {
-      $index = $mapper->getIndex();
-      if (isset($item[$index])) {
-        $item = $item[$index];
-      }
-    }
-
-    if (is_array($item)) {
-      if (array_filter($item)) {
-        $item = reset($item);
-      }
-      else {
-        $item = NULL;
-      }
+    if (!is_array($item)) {
+      $item = [$item];
     }
     $items[0][$path] = $item;
   }
@@ -461,12 +449,15 @@ function capx_tamper_alter_data($entity, &$data, $field_name) {
       // the feeds tamper plugin directly.
       $pre_callback = 'capx_tamper_' . $plugin['callback'];
       $key = 0;
-      if (function_exists($pre_callback)) {
-        $pre_callback($result, $key, $path, $field, $tamper->settings, $tamper->source);
+      foreach ($field as $delta => &$field_data) {
+        if (function_exists($pre_callback)) {
+          $pre_callback($result, $key, $path, $field_data, $tamper->settings, $tamper->source);
+        }
+        // Call the feeds tamper. Then set that value back into the data array.
+        $plugin['callback']($result, $key, $path, $field_data, $tamper->settings, $tamper->source);
+
+        capx_tamper_set_data_by_json_path($data, $path, $field_data, $delta);
       }
-      // Call the feeds tamper. Then set that value back into the data array.
-      $plugin['callback']($result, $key, $path, $field, $tamper->settings, $tamper->source);
-      capx_tamper_set_data_by_json_path($data, $path, $field, $mapper->getIndex());
     }
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed tampers when using wildcards

# Needed By (Date)
- asap

# Urgency
- high

# Steps to Test

1. Checkout this branch.
1. create a mapper and importer, one of the mapped fields should be a wildcard such as `$.titles.*.title`
1. add tampers to that field and other fields
1. import profiles from capx. ensure the wildcard field data from cap has multiple values.
1. ensure all tamper effects occur as expected.



# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)