### PR TITLE
SITES-898: Check for db_field_exists first

### DIFF
--- a/stanford_capx.install
+++ b/stanford_capx.install
@@ -343,7 +343,11 @@ function stanford_capx_update_7200() {
     'not null' => TRUE,
     'default' => '',
   );
-
+  
+  if (!db_field_exists($table, $field)) {
+    db_add_field($table, $field, $spec);
+  }
+  
   db_add_field($table, $field, $spec);
 
 }

--- a/stanford_capx.install
+++ b/stanford_capx.install
@@ -343,11 +343,11 @@ function stanford_capx_update_7200() {
     'not null' => TRUE,
     'default' => '',
   );
-  
+
   if (!db_field_exists($table, $field)) {
     db_add_field($table, $field, $spec);
   }
-  
+
 }
 
 /**

--- a/stanford_capx.install
+++ b/stanford_capx.install
@@ -348,8 +348,6 @@ function stanford_capx_update_7200() {
     db_add_field($table, $field, $spec);
   }
   
-  db_add_field($table, $field, $spec);
-
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SITES-898: Check for existence of db_field 'guuid' during the upgrade.

# Needed By (Date)
- Before the last sun sets on Alderaan. 

# Urgency
- Medium to low

# Steps to Test

1. Clone eastasian to local
2. Replace capx with this branch
3. Run drush updb -y
4. Smile.

# Affected Projects or Products
- Migrations

# Associated Issues and/or People
- SITES-898

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)