### PR TITLE
Fix alter hook name and placement

### DIFF
--- a/includes/CAPx/Drupal/Importer/EntityImporter.php
+++ b/includes/CAPx/Drupal/Importer/EntityImporter.php
@@ -170,7 +170,7 @@ class EntityImporter implements ImporterInterface {
       foreach ($data as $type => $results) {
         foreach ($results as $index => $info) {
           // Allow altering of the results.
-          drupal_alter('stanford_capx_preprocess_results', $info, $this);
+          drupal_alter('capx_preprocess_results', $info, $this);
           $processor = new EntityProcessor($mapper, $info);
           $processor->setEntityImporter($this);
           $processor->execute();

--- a/includes/CAPx/Drupal/Importer/EntityImporter.php
+++ b/includes/CAPx/Drupal/Importer/EntityImporter.php
@@ -168,9 +168,9 @@ class EntityImporter implements ImporterInterface {
 
     if (!empty($data)) {
       foreach ($data as $type => $results) {
+        drupal_alter('capx_preprocess_results', $results, $this);
         foreach ($results as $index => $info) {
           // Allow altering of the results.
-          drupal_alter('capx_preprocess_results', $info, $this);
           $processor = new EntityProcessor($mapper, $info);
           $processor->setEntityImporter($this);
           $processor->execute();

--- a/stanford_capx.api.php
+++ b/stanford_capx.api.php
@@ -255,10 +255,9 @@ function hook_capx_field_processor_widget_alter(&$processor, $type, $field_name,
 }
 
 /**
- * hook_capx_preprocess_results_alter
+ * Act on the results from a API server request.
  *
- * Act on the results from a API server request. This is the first chance you
- * get prior to any processing on the item.
+ * This is the first chance you get prior to any processing on the item.
  *
  * @param array $results
  *   An array of results from a request from the server.


### PR DESCRIPTION
## Purpose:
- Fix alter hook name

## Testing:
- I am not sure that I have actually run the justDoIt() method, I am currently running the "Update profiles now" button on the importer page.  Any advice for running this?

## Notes:
- I had the need to use the hook found here: https://github.com/SU-SWS/stanford_capx/blob/7.x-3.x/stanford_capx.api.php#L268 and found that this alter hook had been put in place but with the module name which was likely an oversight since their is no hook_stanford_capx_preprocess_results_alter hook documented in the api file.