### PR TITLE
Document an undocumented alter hook

### DIFF
--- a/stanford_capx.api.php
+++ b/stanford_capx.api.php
@@ -285,6 +285,18 @@ function hook_capx_preprocess_profile_update_alter(array &$profile, &$importer) 
 }
 
 /**
+ * Act on the results from a API server request.
+ *
+ * This is the first chance you get prior to any processing on the item.
+ *
+ * @param array $results
+ *   An array of results from a request from the server.
+ */
+function hook_capx_orphan_profile_results_alter(array &$results) {
+
+}
+
+/**
  * hook_capx_find_org_orphans_codes_alter
  *
  * Alter the org code lookup for orphans.


### PR DESCRIPTION
## Purpose:
- Document an undocumented alter hook

## Notes:
- I used this hook and noticed it wasn't in the api file.
- It is called here: https://github.com/SU-SWS/stanford_capx/blob/7.x-3.x/includes/CAPx/Drupal/Importer/Orphans/EntityImporterOrphans.php#L113
- If the `capx_preprocess_results` hook didn't have an extra parameter that represents the importer there might be a valid argument to be made for refactoring this to be just one hook.
- My use case was to remove all users that had a specific "position" from being imported so I added the logic to this hook also to make sure that the users were marked as orphans too.