### PR TITLE
SITES-000: Do not save reference field values.

### DIFF
--- a/includes/CAPx/Drupal/Processors/FieldProcessors/EntityReferenceFieldProcessor.php
+++ b/includes/CAPx/Drupal/Processors/FieldProcessors/EntityReferenceFieldProcessor.php
@@ -6,7 +6,7 @@
 
 namespace CAPx\Drupal\Processors\FieldProcessors;
 
-class EntityReferenceFieldProcessor {
+class EntityReferenceFieldProcessor extends FieldProcessor {
 
   protected $entity;
   protected $fieldName;
@@ -20,6 +20,7 @@ class EntityReferenceFieldProcessor {
    * Default implementation of put.
    */
   public function put($relatedEntity) {
+
     $id = $relatedEntity->getIdentifier();
     $entity = $this->entity;
     $field = $entity->{$this->fieldName};
@@ -39,6 +40,5 @@ class EntityReferenceFieldProcessor {
         break;
     }
   }
-
 
 }

--- a/includes/CAPx/Drupal/Processors/FieldProcessors/EntityReferenceFieldProcessor.php
+++ b/includes/CAPx/Drupal/Processors/FieldProcessors/EntityReferenceFieldProcessor.php
@@ -6,7 +6,7 @@
 
 namespace CAPx\Drupal\Processors\FieldProcessors;
 
-class EntityReferenceFieldProcessor extends FieldProcessor {
+class EntityReferenceFieldProcessor {
 
   protected $entity;
   protected $fieldName;

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -1008,6 +1008,10 @@ function stanford_capx_mapper_form_submit($form, $form_state) {
       if (empty(array_filter($value))) {
         unset($fields[$key]);
       }
+      // Trim out reference fields from the config array.
+      if (isset($value[0]) && $value[0] == "none") {
+        unset($fields[$key]);
+      }
     }
     $settings['fields'] = $fields;
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- `none` gets saved to the mapping config and causes issues.

# Needed By (Date)
- Week of March 25 - 29

# Urgency
- Medium, Physics cannot edit their mappers until this has been resolved and deployed.

# Steps to Test

1. Sync the physics.stanford.edu (physics2) site down to local
2. Edit and save the mappers though the UI while on capx branch 7.x-3.x
3. Run imports and see batch error
4. Check out this branch and edit and save the mappers again.
5. Run importers and see batch finish.

# Affected Projects or Products
- CAPX
- Anyone mapping to a content type with entity reference fields.

# Associated Issues and/or People
- Issue came in through Slack.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)