### PR TITLE
Update stanford_capx.forms.inc

### DIFF
--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -2083,11 +2083,11 @@ function stanford_capx_form_views_exposed_form_alter(&$form, &$form_state) {
  *
  * @see stanford_capx_mapper_form_validate_element()
  */
-function stanford_capx_schema_format_validation($schema = NULL) {
+function stanford_capx_schema_format_validation($schema = NULL, $recursive = 0) {
   $formatted_schema = array();
 
   // Load the schema when not making a recursive function call (the first call).
-  if (empty($schema)) {
+  if (empty($schema) && $recursive === 0) {
     $schema = stanford_capx_schema_load('array');
   }
 
@@ -2096,11 +2096,11 @@ function stanford_capx_schema_format_validation($schema = NULL) {
     // @TODO: Remove isset() when the schema is fully documented.
     if ($schema['type'] == 'object' && isset($schema['properties'])) {
       foreach ($schema['properties'] as $name => $property) {
-        $formatted_schema[$name] = stanford_capx_schema_format_validation($property);
+        $formatted_schema[$name] = stanford_capx_schema_format_validation($property, 1);
       }
     }
-    elseif ($schema['type'] == 'array') {
-      $formatted_schema = array(stanford_capx_schema_format_validation($schema['items']));
+    elseif ($schema['type'] == 'array' && isset($schema['items'])) {
+      $formatted_schema = [stanford_capx_schema_format_validation($schema['items'], 1)];
     }
     else {
       // Leaf element set to a string explaining the data type. E.g. 'integer'.

--- a/stanford_capx.forms.inc
+++ b/stanford_capx.forms.inc
@@ -2083,11 +2083,11 @@ function stanford_capx_form_views_exposed_form_alter(&$form, &$form_state) {
  *
  * @see stanford_capx_mapper_form_validate_element()
  */
-function stanford_capx_schema_format_validation($schema = NULL, $recursive = 0) {
+function stanford_capx_schema_format_validation($schema = NULL) {
   $formatted_schema = array();
 
   // Load the schema when not making a recursive function call (the first call).
-  if (empty($schema) && $recursive === 0) {
+  if (empty($schema)) {
     $schema = stanford_capx_schema_load('array');
   }
 
@@ -2096,11 +2096,11 @@ function stanford_capx_schema_format_validation($schema = NULL, $recursive = 0) 
     // @TODO: Remove isset() when the schema is fully documented.
     if ($schema['type'] == 'object' && isset($schema['properties'])) {
       foreach ($schema['properties'] as $name => $property) {
-        $formatted_schema[$name] = stanford_capx_schema_format_validation($property, 1);
+        $formatted_schema[$name] = stanford_capx_schema_format_validation($property);
       }
     }
     elseif ($schema['type'] == 'array' && isset($schema['items'])) {
-      $formatted_schema = [stanford_capx_schema_format_validation($schema['items'], 1)];
+      $formatted_schema = [stanford_capx_schema_format_validation($schema['items'])];
     }
     else {
       // Leaf element set to a string explaining the data type. E.g. 'integer'.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Prevents recursive error on mapper validation with new schema from the api
- New schema data from the api doesn't always have an 'items' key when an array element is declared. The code was incorrectly assuming that all array schema elements had items. 

# Needed By (Date)
- ASAP.

# Urgency
-  All sites with the new schema information will fail. 

# Steps to Test

1. Install a jumpstart site and enable the capx module
2. Connect to the api by entering in the username and password credentials
3. Create a new people mapper and save the form. Get recursion error
4. Check out this branch and repeat step three
5. Form works!

# Affected Projects or Products
- All sites using CAPx

# Associated Issues and/or People
- https://stanfordwebservices.slack.com/archives/G0A50QC49/p1558710399002600
- TASK00084060
- @rebeccahongsf 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)