### PR TITLE
DEVOPS-222: Re-run encryption of variables

### DIFF
--- a/stanford_capx.install
+++ b/stanford_capx.install
@@ -440,6 +440,14 @@ function stanford_capx_update_7301() {
 }
 
 /**
+ * Upgrade path for PHP 7.2 for those who missed it in 7301.
+ */
+function stanford_capx_update_7302() {
+  // We could check the encryption method of the username and password variables here, but it's probably not worth the effort.
+  stanford_capx_update_7301();
+}
+
+/**
  * Create the encryption settings for use in CAPx.
  */
 function stanford_capx_install_encrypt_settings() {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Decrypt and encrypt `stanford_capx_username` and `stanford_capx_password` in order to remove dependency on mcrypt.

# Needed By (Date)
- ASAP

# Criticality
- How critical is this PR on a 1-10 scale? 10/10
- Was causing fatal errors with PHP 7.2 and prevents us from upgrading to PHP 7.2

# Steps to Test

1. In conjunction with https://github.com/SU-SWS/acsf-cardinald7/pull/243 (which is checked out on `dev`), restore a database dump from for `physics2`, `jumpstartenergy`, and/or `paleobiology`. You will need the `encrypt_drupal_variable_key` variable to be set, and it appears that ACSF strips that out when cloning to lower environments
2. Run `drush -y updb`
3. Run `drush vget stanford_capx_password` and `drush vget stanford_capx_username` and ensure that it indicates `s:6:"method";s:7:"openssl";`
4. Run `drush cron` and ensure that nodes from CAP are imported
5. Review code and opine whether we should bother checking if the method is already openssl. I'm not sure how widespread this is, but I don't see the harm in just decrypting and re-encrypting.

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: DEVOPS-222
- Other PRs: https://github.com/SU-SWS/acsf-cardinald7/pull/243
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? ( @sherakama )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)