### PR TITLE
DEVOPS-222: Set default encryption profile at install time

### DIFF
--- a/stanford_capx.install
+++ b/stanford_capx.install
@@ -431,7 +431,6 @@ function stanford_capx_update_7301() {
 
   // Install the new encrypt settings.
   stanford_capx_install_encrypt_settings();
-  variable_set('encrypt_default_config', STANFORD_CAPX_ENCRYPT_PROFILE);
 
   // Save the old credentials with the new method.
   variable_set('stanford_capx_username', encrypt($username));
@@ -482,4 +481,7 @@ function stanford_capx_install_encrypt_settings() {
   ];
 
   encrypt_save_config($settings);
+
+  // Set this to be the default profile for the Encrypt module.
+  variable_set('encrypt_default_config', $key_name);
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes borked installs on PHP 7.2+

# Needed By (Date)
- ASAP

# Criticality
- How critical is this PR on a 1-10 scale? 7/10
- Affects all new installs

# Steps to Test

1. Check out 7.x-3.0-beta16
2. Do a fresh install
3. Try to submit the CAP credentials
4. Weep at the fatal error before you
5. Check out this branch
6. Reinstall your site and reinstall this module
7. Repeat Step 3
8. Rejoice

# Affected Projects or Products
- CAPx
- New D7 sites

# Associated Issues and/or People
- JIRA ticket: DEVOPS-222
- Anyone who should be notified? (@pookmish )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)